### PR TITLE
feat(api): add terms query

### DIFF
--- a/src/Queries/TermsQuery.php
+++ b/src/Queries/TermsQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Queries;
+
+class TermsQuery implements Query
+{
+    protected string $field;
+
+    protected array $values;
+
+    public static function create(string $field, array $values): static
+    {
+        return new self($field, $values);
+    }
+
+    public function __construct(string $field, array $values)
+    {
+        $this->field = $field;
+        $this->values = $values;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'terms' => [
+                $this->field => $this->values,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Thank you for this excellent package. Exactly what I needed while battling raw arrays with the native elasticsearch php client.

I missed the `terms` query, I have this logic running locally using a custom implementation. Maybe you're interested in it being included in the package. Please mention me if you need more information as my GitHub notifications pile up too quickly to use the normal way of using them.

Adds support for the v7 terms query in dsl, see https://www.elastic.co/guide/en/elasticsearch/reference/7.15/query-dsl-terms-query.html