### PR TITLE
Fix `Builder::search()` return data type

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -3,6 +3,8 @@
 namespace Spatie\ElasticsearchQueryBuilder;
 
 use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use Http\Promise\Promise;
 use Spatie\ElasticsearchQueryBuilder\Aggregations\Aggregation;
 use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\Query;
@@ -65,7 +67,7 @@ class Builder
         return $this;
     }
 
-    public function search(): array
+    public function search(): Elasticsearch|Promise
     {
         $payload = $this->getPayload();
 


### PR DESCRIPTION
This PR fixes issue #22 introduced by PR #19.

The return data type of the `search` method was changed from `array` on v7.x 
to `Elasticsearch|Promise` in v8.x.