### PR TITLE
boolean support for MatchQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The following query types are available:
 
 ```php
 \Spatie\ElasticsearchQueryBuilder\Queries\MatchQuery::create('name', 'john doe', fuzziness: 2);
+\Spatie\ElasticsearchQueryBuilder\Queries\MatchQuery::create('age', 22);
+\Spatie\ElasticsearchQueryBuilder\Queries\MatchQuery::create('active', false);
 ```
 
 #### `MultiMatchQuery`

--- a/src/Queries/MatchQuery.php
+++ b/src/Queries/MatchQuery.php
@@ -14,7 +14,7 @@ class MatchQuery implements Query
 
     public function __construct(
         protected string $field,
-        protected string | int $query,
+        protected string | int | bool $query,
         protected null | string | int $fuzziness = null
     ) {
     }

--- a/src/Queries/MatchQuery.php
+++ b/src/Queries/MatchQuery.php
@@ -6,7 +6,7 @@ class MatchQuery implements Query
 {
     public static function create(
         string $field,
-        string | int $query,
+        string | int | bool $query,
         null | string | int $fuzziness = null
     ): self {
         return new self($field, $query, $fuzziness);


### PR DESCRIPTION
There was no support for creating a match query for boolean fields.

Elasticsearch documentation does support boolean fields:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#match-field-params
