### PR TITLE
Allow bool and int as types for term query

### DIFF
--- a/src/Queries/TermQuery.php
+++ b/src/Queries/TermQuery.php
@@ -6,14 +6,14 @@ class TermQuery implements Query
 {
     protected string $field;
 
-    protected string $value;
+    protected bool|int|string $value;
 
-    public static function create(string $field, string $value): static
+    public static function create(string $field, bool|int|string $value): static
     {
         return new self($field, $value);
     }
 
-    public function __construct(string $field, string $value)
+    public function __construct(string $field, bool|int|string $value)
     {
         $this->field = $field;
         $this->value = $value;


### PR DESCRIPTION
While the elasticsearch docs make only an example of string values, other types work just fine.