### PR TITLE
Fix: Add return for size and from at getPayload

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -136,6 +136,14 @@ class Builder
     {
         $payload = [];
 
+        if ($this->from !== null) {
+            $payload['from'] = $this->from;
+        }
+
+        if ($this->size !== null) {
+            $payload['size'] = $this->size;
+        }
+
         if ($this->query) {
             $payload['query'] = $this->query->toArray();
         }


### PR DESCRIPTION
Add support for returning the size and from at getPayload.

Since size and from could be 0 e.g. when just using aggregations or on page 1. Check if var is nut null.

Tested and working with this example query:
$builder->index('test_*')
	->size(1000)
	->from(0)
	->addQuery(TermQuery::create('id', $id),'filter')
	->addQuery(RangeQuery::create('@timestamp')
		->gte("now-24h")
		->lte("now")
        );

Workaround for this could be:
$query = array_merge(array('size' => 1000), $builder->getPayload());
$query = array_merge(array('from' => 0), $query));