### PR TITLE
Add minimum_should_match support for BoolQuery

### DIFF
--- a/src/Queries/BoolQuery.php
+++ b/src/Queries/BoolQuery.php
@@ -11,6 +11,8 @@ class BoolQuery implements Query
     protected array $should = [];
     protected array $must_not = [];
 
+    protected ?string $minimumShouldMatch = null;
+
     public static function create(): static
     {
         return new self();
@@ -27,6 +29,12 @@ class BoolQuery implements Query
         return $this;
     }
 
+    public function minimumShouldMatch(?string $value): static
+    {
+        $this->minimumShouldMatch = $value;
+        return $this;
+    }
+
     public function toArray(): array
     {
         $bool = [
@@ -35,6 +43,11 @@ class BoolQuery implements Query
             'should' => array_map(fn (Query $query) => $query->toArray(), $this->should),
             'must_not' => array_map(fn (Query $query) => $query->toArray(), $this->must_not),
         ];
+
+        if ($this->minimumShouldMatch) {
+            $bool["minimum_should_match"] = $this->minimumShouldMatch;
+        }
+
 
         return [
             'bool' => array_filter($bool),


### PR DESCRIPTION
Updates BoolQuery to allow for setting the [minimum_should_match](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html) option

- This option is a string with a variety of formats, so it made sense to me to just keep it as a string value
- If the option is not set, nothing is added to the payload

This option is very useful when you need it, but is perhaps somewhat niche - would you want it added to the readme?