### PR TITLE
added docker-compose.yml with composer, test, psalm and format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,10 @@
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "8.0"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  composer:
+    image: composer:latest
+    volumes:
+      - .:/app
+
+  test:
+    image: php:8.0-cli
+    working_dir: "/usr/src/myapp"
+    volumes:
+      - .:/usr/src/myapp
+    entrypoint: "vendor/bin/phpunit"
+
+  psalm:
+    image: php:8.0-cli
+    working_dir: "/usr/src/myapp"
+    volumes:
+      - .:/usr/src/myapp
+    entrypoint: "vendor/bin/psalm"
+
+  format:
+    image: php:8.0-cli
+    working_dir: "/usr/src/myapp"
+    volumes:
+      - .:/usr/src/myapp
+    entrypoint: "vendor/bin/php-cs-fixer fix --allow-risky=yes"


### PR DESCRIPTION
This will make local development easier

`docker-compose run --rm composer install` to install composer dependencies
`docker-compose run --rm test` to run tests
`docker-compose run --rm psalm` to run psalm
`docker-compose run --rm format` to format with php-cs-fixer

I had to add `platform.php` to composer.json as it will be using official composer image which might use different PHP version and there might be issues around dependencies.