### PR TITLE
NestedQuery improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ The following query types are available:
 );
 ```
 
+##### `NestedQuery` `InnerHits`
+
+[https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html)
+
+```php
+$nestedQuery = \Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery::create(
+    'comments',
+    \Spatie\ElasticsearchQueryBuilder\Queries\TermsQuery::create('comments.published', true)
+);
+
+$nestedQuery->innerHits(
+    \Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits::create('top_three_liked_comments')
+        ->size(3)
+        ->addSort(
+            \Spatie\ElasticsearchQueryBuilder\Sorts\Sort::create(
+                'comments.likes', 
+                \Spatie\ElasticsearchQueryBuilder\Sorts\Sort::DESC
+            )
+        )
+        ->fields(['comments.content', 'comments.author', 'comments.likes'])
+);
+```
+
 #### `RangeQuery`
 
 [https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html)

--- a/src/Queries/InnerHits.php
+++ b/src/Queries/InnerHits.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Queries;
+
+class InnerHits
+{
+    public static function create(): self
+    {
+        return new InnerHits();
+    }
+
+    public function __construct(
+        protected ?int $from = null,
+        protected ?int $size = null,
+        protected ?string $name = null
+    ) {
+    }
+
+    public function from(int $from): self
+    {
+        $this->from = $from;
+
+        return $this;
+    }
+
+    public function size(int $size): self
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function name(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getPayload(): array
+    {
+        return array_filter(
+            [
+                'from' => $this->from,
+                'size' => $this->size,
+                'name' => $this->name,
+            ]
+        );
+    }
+}

--- a/src/Queries/InnerHits.php
+++ b/src/Queries/InnerHits.php
@@ -2,6 +2,9 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Queries;
 
+use Spatie\ElasticsearchQueryBuilder\SortCollection;
+use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;
+
 class InnerHits
 {
     public static function create(): self
@@ -12,7 +15,8 @@ class InnerHits
     public function __construct(
         protected ?int $from = null,
         protected ?int $size = null,
-        protected ?string $name = null
+        protected ?string $name = null,
+        protected ?SortCollection $sorts = null
     ) {
     }
 
@@ -37,6 +41,17 @@ class InnerHits
         return $this;
     }
 
+    public function addSort(Sort $sort): self
+    {
+        if (! $this->sorts) {
+            $this->sorts = new SortCollection();
+        }
+
+        $this->sorts->add($sort);
+
+        return $this;
+    }
+
     public function getPayload(): array
     {
         return array_filter(
@@ -44,6 +59,7 @@ class InnerHits
                 'from' => $this->from,
                 'size' => $this->size,
                 'name' => $this->name,
+                'sort' => $this->sorts?->toArray(),
             ]
         );
     }

--- a/src/Queries/NestedQuery.php
+++ b/src/Queries/NestedQuery.php
@@ -13,7 +13,8 @@ class NestedQuery implements Query
         protected string $path,
         protected Query $query,
         protected ?string $scoreMode = null,
-        protected ?bool $ignoreUnmapped = null
+        protected ?bool $ignoreUnmapped = null,
+        protected ?InnerHits $innerHits = null
     ) {
     }
 
@@ -31,6 +32,13 @@ class NestedQuery implements Query
         return $this;
     }
 
+    public function innerHits(InnerHits $innerHits): self
+    {
+        $this->innerHits = $innerHits;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return [
@@ -40,6 +48,7 @@ class NestedQuery implements Query
                     'query' => $this->query->toArray(),
                     'score_mode' => $this->scoreMode,
                     'ignore_unmapped' => $this->ignoreUnmapped,
+                    'inner_hits' => $this->innerHits?->getPayload()
                 ]
             ),
         ];

--- a/src/Queries/NestedQuery.php
+++ b/src/Queries/NestedQuery.php
@@ -4,30 +4,35 @@ namespace Spatie\ElasticsearchQueryBuilder\Queries;
 
 class NestedQuery implements Query
 {
-    protected string $path;
-
-    protected Query $query;
-
     public static function create(string $path, Query $query): self
     {
         return new self($path, $query);
     }
 
     public function __construct(
-        string $path,
-        Query $query
+        protected string $path,
+        protected Query $query,
+        protected ?string $scoreMode = null
     ) {
-        $this->path = $path;
-        $this->query = $query;
+    }
+
+    public function scoreMode(string $scoreMode): self
+    {
+        $this->scoreMode = $scoreMode;
+
+        return $this;
     }
 
     public function toArray(): array
     {
         return [
-            'nested' => [
-                'path' => $this->path,
-                'query' => $this->query->toArray(),
-            ],
+            'nested' => array_filter(
+                [
+                    'path' => $this->path,
+                    'query' => $this->query->toArray(),
+                    'score_mode' => $this->scoreMode,
+                ]
+            ),
         ];
     }
 }

--- a/src/Queries/NestedQuery.php
+++ b/src/Queries/NestedQuery.php
@@ -12,13 +12,21 @@ class NestedQuery implements Query
     public function __construct(
         protected string $path,
         protected Query $query,
-        protected ?string $scoreMode = null
+        protected ?string $scoreMode = null,
+        protected ?bool $ignoreUnmapped = null
     ) {
     }
 
     public function scoreMode(string $scoreMode): self
     {
         $this->scoreMode = $scoreMode;
+
+        return $this;
+    }
+
+    public function ignoreUnmapped(bool $ignoreUnmapped): self
+    {
+        $this->ignoreUnmapped = $ignoreUnmapped;
 
         return $this;
     }
@@ -31,6 +39,7 @@ class NestedQuery implements Query
                     'path' => $this->path,
                     'query' => $this->query->toArray(),
                     'score_mode' => $this->scoreMode,
+                    'ignore_unmapped' => $this->ignoreUnmapped,
                 ]
             ),
         ];

--- a/src/Queries/NestedQuery.php
+++ b/src/Queries/NestedQuery.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Queries;
 
+use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
+
 class NestedQuery implements Query
 {
     public static function create(string $path, Query $query): self

--- a/src/Queries/NestedQuery.php
+++ b/src/Queries/NestedQuery.php
@@ -6,6 +6,12 @@ use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
 
 class NestedQuery implements Query
 {
+    public const SCORE_MODE_AVG = 'avg';
+    public const SCORE_MODE_MAX = 'max';
+    public const SCORE_MODE_MIN = 'min';
+    public const SCORE_MODE_NONE = 'none';
+    public const SCORE_MODE_SUM = 'sum';
+
     public static function create(string $path, Query $query): self
     {
         return new self($path, $query);

--- a/src/Queries/NestedQuery.php
+++ b/src/Queries/NestedQuery.php
@@ -50,7 +50,7 @@ class NestedQuery implements Query
                     'query' => $this->query->toArray(),
                     'score_mode' => $this->scoreMode,
                     'ignore_unmapped' => $this->ignoreUnmapped,
-                    'inner_hits' => $this->innerHits?->getPayload()
+                    'inner_hits' => $this->innerHits?->toArray()
                 ]
             ),
         ];

--- a/src/Queries/NestedQuery/InnerHits.php
+++ b/src/Queries/NestedQuery/InnerHits.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\ElasticsearchQueryBuilder\Queries;
+namespace Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery;
 
 use Spatie\ElasticsearchQueryBuilder\SortCollection;
 use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;

--- a/src/Queries/NestedQuery/InnerHits.php
+++ b/src/Queries/NestedQuery/InnerHits.php
@@ -7,18 +7,18 @@ use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;
 
 class InnerHits
 {
-    public static function create(): self
+    public static function create(string $name): self
     {
-        return new InnerHits();
+        return new InnerHits($name);
     }
 
     /**
      * @param string[]|null $fields
      */
     public function __construct(
+        protected string $name,
         protected ?int $from = null,
         protected ?int $size = null,
-        protected ?string $name = null,
         protected ?SortCollection $sorts = null,
         protected ?array $fields = null
     ) {
@@ -34,13 +34,6 @@ class InnerHits
     public function size(int $size): self
     {
         $this->size = $size;
-
-        return $this;
-    }
-
-    public function name(string $name): self
-    {
-        $this->name = $name;
 
         return $this;
     }

--- a/src/Queries/NestedQuery/InnerHits.php
+++ b/src/Queries/NestedQuery/InnerHits.php
@@ -12,11 +12,15 @@ class InnerHits
         return new InnerHits();
     }
 
+    /**
+     * @param string[]|null $fields
+     */
     public function __construct(
         protected ?int $from = null,
         protected ?int $size = null,
         protected ?string $name = null,
-        protected ?SortCollection $sorts = null
+        protected ?SortCollection $sorts = null,
+        protected ?array $fields = null
     ) {
     }
 
@@ -41,6 +45,16 @@ class InnerHits
         return $this;
     }
 
+    /**
+     * @param string[] $fields
+     */
+    public function fields(array $fields): self
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
     public function addSort(Sort $sort): self
     {
         if (! $this->sorts) {
@@ -52,7 +66,7 @@ class InnerHits
         return $this;
     }
 
-    public function getPayload(): array
+    public function toArray(): array
     {
         return array_filter(
             [
@@ -60,6 +74,7 @@ class InnerHits
                 'size' => $this->size,
                 'name' => $this->name,
                 'sort' => $this->sorts?->toArray(),
+                '_source' => $this->fields
             ]
         );
     }

--- a/tests/Queries/NestedQuery/InnerHitsTest.php
+++ b/tests/Queries/NestedQuery/InnerHitsTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries\NestedQuery;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
 use PHPUnit\Framework\TestCase;
 use Spatie\ElasticsearchQueryBuilder\SortCollection;
@@ -10,54 +9,46 @@ use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;
 
 class InnerHitsTest extends TestCase
 {
-    private SortCollection|MockObject $sortsMock;
-
     private InnerHits $innerHits;
 
     protected function setUp(): void
     {
-        $this->innerHits = new InnerHits();
+        $this->innerHits = new InnerHits('test');
     }
 
     public function testToArrayBuildsCorrectInnerHits(): void
     {
         $this->assertEquals(
-            [],
+            [
+                'name' => 'test',
+            ],
             $this->innerHits->toArray()
         );
     }
 
-    public function testToArrayBuildsCorrectInnerHitsWithName(): void
+    public function testToArrayBuildsCorrectInnerHitsWithFrom(): void
     {
         $this->assertEquals(
             [
                 'name' => 'test',
-            ],
-            $this->innerHits->name('test')->toArray()
-        );
-    }
-
-    public function testToArrayBuildsCorrectInnerHitsPayloadWithFrom(): void
-    {
-        $this->assertEquals(
-            [
                 'from' => 123,
             ],
             $this->innerHits->from(123)->toArray()
         );
     }
 
-    public function testToArrayBuildsCorrectInnerHitsPayloadWithSize(): void
+    public function testToArrayBuildsCorrectInnerHitsWithSize(): void
     {
         $this->assertEquals(
             [
+                'name' => 'test',
                 'size' => 123,
             ],
             $this->innerHits->size(123)->toArray()
         );
     }
 
-    public function testToArrayBuildsCorrectInnerHitsPayloadWithSorts(): void
+    public function testToArrayBuildsCorrectInnerHitsWithSorts(): void
     {
         $sortMock = $this->createMock(Sort::class);
 
@@ -67,6 +58,7 @@ class InnerHitsTest extends TestCase
 
         $this->assertEquals(
             [
+                'name' => 'test',
                 'sort' => [
                     [
                         'field' => [
@@ -94,7 +86,7 @@ class InnerHitsTest extends TestCase
             ->method('add')
             ->with($sortMock);
 
-        $innerHits = new InnerHits(sorts: $sortsMock);
+        $innerHits = new InnerHits('test', sorts: $sortsMock);
 
         $innerHits->addSort($sortMock);
     }

--- a/tests/Queries/NestedQuery/InnerHitsTest.php
+++ b/tests/Queries/NestedQuery/InnerHitsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries\NestedQuery;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\SortCollection;
+use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;
+
+class InnerHitsTest extends TestCase
+{
+    private SortCollection|MockObject $sortsMock;
+
+    private InnerHits $innerHits;
+
+    protected function setUp(): void
+    {
+        $this->innerHits = new InnerHits();
+    }
+
+    public function testToArrayBuildsCorrectInnerHits(): void
+    {
+        $this->assertEquals(
+            [],
+            $this->innerHits->toArray()
+        );
+    }
+
+    public function testToArrayBuildsCorrectInnerHitsWithName(): void
+    {
+        $this->assertEquals(
+            [
+                'name' => 'test',
+            ],
+            $this->innerHits->name('test')->toArray()
+        );
+    }
+
+    public function testToArrayBuildsCorrectInnerHitsPayloadWithFrom(): void
+    {
+        $this->assertEquals(
+            [
+                'from' => 123,
+            ],
+            $this->innerHits->from(123)->toArray()
+        );
+    }
+
+    public function testToArrayBuildsCorrectInnerHitsPayloadWithSize(): void
+    {
+        $this->assertEquals(
+            [
+                'size' => 123,
+            ],
+            $this->innerHits->size(123)->toArray()
+        );
+    }
+
+    public function testToArrayBuildsCorrectInnerHitsPayloadWithSorts(): void
+    {
+        $sortMock = $this->createMock(Sort::class);
+
+        $sortMock
+            ->method('toArray')
+            ->willReturn(['field' => ['order' => Sort::ASC]]);
+
+        $this->assertEquals(
+            [
+                'sort' => [
+                    [
+                        'field' => [
+                            'order' => Sort::ASC,
+                        ]
+                    ]
+                ]
+            ],
+            $this->innerHits->addSort($sortMock)->toArray()
+        );
+    }
+
+    public function testAddSortAddsSortToSorts(): void
+    {
+        $sortMock = $this->createMock(Sort::class);
+
+        $sortMock
+            ->method('toArray')
+            ->willReturn(['sort']);
+
+        $sortsMock = $this->createMock(SortCollection::class);
+
+        $sortsMock
+            ->expects($this->once())
+            ->method('add')
+            ->with($sortMock);
+
+        $innerHits = new InnerHits(sorts: $sortsMock);
+
+        $innerHits->addSort($sortMock);
+    }
+}

--- a/tests/Queries/NestedQueryTest.php
+++ b/tests/Queries/NestedQueryTest.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
 
-use PHPUnit\Framework\MockObject\MockObject;
+use Spatie\ElasticsearchQueryBuilder\Queries\InnerHits;
 use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery;
 use PHPUnit\Framework\TestCase;
 use Spatie\ElasticsearchQueryBuilder\Queries\Query;
@@ -60,6 +60,33 @@ class NestedQueryTest extends TestCase
                 ]
             ],
             $this->nestedQuery->ignoreUnmapped(true)->toArray()
+        );
+    }
+
+    public function testToArrayBuildsCorrectNestedQueryWithInnerHits(): void
+    {
+        $innerHitsMock = $this->createMock(InnerHits::class);
+        $innerHitsMock
+            ->method('getPayload')
+            ->willReturn(
+                [
+                    'size' => 10,
+                    'name' => 'test'
+                ]
+            );
+
+        $this->assertEquals(
+            [
+                'nested' => [
+                    'path' => 'path',
+                    'query' => ['query'],
+                    'inner_hits' => [
+                        'size' => 10,
+                        'name' => 'test'
+                    ]
+                ]
+            ],
+            $this->nestedQuery->innerHits($innerHitsMock)->toArray()
         );
     }
 }

--- a/tests/Queries/NestedQueryTest.php
+++ b/tests/Queries/NestedQueryTest.php
@@ -34,4 +34,18 @@ class NestedQueryTest extends TestCase
             $this->nestedQuery->toArray()
         );
     }
+
+    public function testToArrayBuildsCorrectNestedQueryWithScoreMode(): void
+    {
+        $this->assertEquals(
+            [
+                'nested' => [
+                    'path' => 'path',
+                    'query' => ['query'],
+                    'score_mode' => 'min',
+                ]
+            ],
+            $this->nestedQuery->scoreMode('min')->toArray()
+        );
+    }
 }

--- a/tests/Queries/NestedQueryTest.php
+++ b/tests/Queries/NestedQueryTest.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
 
-use Spatie\ElasticsearchQueryBuilder\Queries\InnerHits;
-use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery;
 use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
 use Spatie\ElasticsearchQueryBuilder\Queries\Query;
 
 class NestedQueryTest extends TestCase

--- a/tests/Queries/NestedQueryTest.php
+++ b/tests/Queries/NestedQueryTest.php
@@ -42,10 +42,10 @@ class NestedQueryTest extends TestCase
                 'nested' => [
                     'path' => 'path',
                     'query' => ['query'],
-                    'score_mode' => 'min',
+                    'score_mode' => NestedQuery::SCORE_MODE_MIN,
                 ]
             ],
-            $this->nestedQuery->scoreMode('min')->toArray()
+            $this->nestedQuery->scoreMode(NestedQuery::SCORE_MODE_MIN)->toArray()
         );
     }
 

--- a/tests/Queries/NestedQueryTest.php
+++ b/tests/Queries/NestedQueryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery;
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Queries\Query;
+
+class NestedQueryTest extends TestCase
+{
+    private NestedQuery $nestedQuery;
+
+    protected function setUp(): void
+    {
+        $queryMock = $this->createMock(Query::class);
+
+        $queryMock
+            ->method('toArray')
+            ->willReturn(['query']);
+
+        $this->nestedQuery = new NestedQuery('path', $queryMock);
+    }
+
+    public function testToArrayBuildsCorrectNestedQuery(): void
+    {
+        $this->assertEquals(
+            [
+                'nested' => [
+                    'path' => 'path',
+                    'query' => ['query']
+                ]
+            ],
+            $this->nestedQuery->toArray()
+        );
+    }
+}

--- a/tests/Queries/NestedQueryTest.php
+++ b/tests/Queries/NestedQueryTest.php
@@ -67,7 +67,7 @@ class NestedQueryTest extends TestCase
     {
         $innerHitsMock = $this->createMock(InnerHits::class);
         $innerHitsMock
-            ->method('getPayload')
+            ->method('toArray')
             ->willReturn(
                 [
                     'size' => 10,

--- a/tests/Queries/NestedQueryTest.php
+++ b/tests/Queries/NestedQueryTest.php
@@ -48,4 +48,18 @@ class NestedQueryTest extends TestCase
             $this->nestedQuery->scoreMode('min')->toArray()
         );
     }
+
+    public function testToArrayBuildsCorrectNestedQueryWithIgnoreUnmapped(): void
+    {
+        $this->assertEquals(
+            [
+                'nested' => [
+                    'path' => 'path',
+                    'query' => ['query'],
+                    'ignore_unmapped' => true,
+                ]
+            ],
+            $this->nestedQuery->ignoreUnmapped(true)->toArray()
+        );
+    }
 }


### PR DESCRIPTION
* Added tests for `NestedQuery`.
* Updated `NestedQuery` to use promoted properties.
* Added `ignore_unmapped` and `score_mode` to `NestedQuery`.
* Added `inner_hits` ([https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html)) to `NestedQuery` .
    *  `name` is not required for `inner_hits` to work but, I have made it required as when `toArray` is called without anything set it will produce empty `array` and that's not valid `inner_hits`.
* Updated `README.md` to include section about `InnerHits`.