### PR TITLE
Add boost parameter to Terms query

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The following query types are available:
 [https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html)
 
 ```php
-\Spatie\ElasticsearchQueryBuilder\Queries\TermsQuery::create('user.id', ['flx', 'fly']);
+\Spatie\ElasticsearchQueryBuilder\Queries\TermsQuery::create('user.id', ['flx', 'fly'], boost: 5.0);
 ```
 
 #### `WildcardQuery`

--- a/src/Queries/MatchQuery.php
+++ b/src/Queries/MatchQuery.php
@@ -35,7 +35,7 @@ class MatchQuery implements Query
             $match['match'][$this->field]['fuzziness'] = $this->fuzziness;
         }
 
-        if ($this->boost) {
+        if ($this->boost !== null) {
             $match['match'][$this->field]['boost'] = $this->boost;
         }
 

--- a/src/Queries/TermsQuery.php
+++ b/src/Queries/TermsQuery.php
@@ -8,12 +8,12 @@ class TermsQuery implements Query
 
     protected array $value;
 
-    public static function create(string $field, array $value): static
+    public static function create(string $field, array $value, null | float $boost = null): static
     {
-        return new self($field, $value);
+        return new self($field, $value, $boost);
     }
 
-    public function __construct(string $field, array $value)
+    public function __construct(string $field, array $value, protected null | float $boost = null)
     {
         $this->field = $field;
         $this->value = $value;
@@ -21,10 +21,16 @@ class TermsQuery implements Query
 
     public function toArray(): array
     {
-        return [
+        $terms = [
             'terms' => [
                 $this->field => $this->value,
             ],
         ];
+
+        if ($this->boost) {
+            $terms['terms']['boost'] = $this->boost;
+        }
+
+        return $terms;
     }
 }

--- a/src/Queries/TermsQuery.php
+++ b/src/Queries/TermsQuery.php
@@ -27,7 +27,7 @@ class TermsQuery implements Query
             ],
         ];
 
-        if ($this->boost) {
+        if ($this->boost !== null) {
             $terms['terms']['boost'] = $this->boost;
         }
 


### PR DESCRIPTION
* Adds support for the boost parameter in `TermsQuery`, similar to https://github.com/spatie/elasticsearch-query-builder/pull/42. 
* Updates the boost condition in `MatchQuery` to check for not null values instead of falsy values.