### PR TITLE
Use Elasticsearch contract instead of concrete class in constructor

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\ElasticsearchQueryBuilder;
 
-use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use Http\Promise\Promise;
 use Spatie\ElasticsearchQueryBuilder\Aggregations\Aggregation;
@@ -36,7 +36,7 @@ class Builder
 
     protected ?BoolQuery $postFilterQuery = null;
 
-    public function __construct(protected Client $client)
+    public function __construct(protected ClientInterface $client)
     {
     }
 


### PR DESCRIPTION
For service containers to correctly handle dependency injection we should pass the interface instead of the concrete implementation of the Elasticsearch PHP Client.