### PR TITLE
Add percolate query

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ The following query types are available:
 \Spatie\ElasticsearchQueryBuilder\Queries\WildcardQuery::create('user.id', '*doe');
 ```
 
+#### `PercolateQuery`
+
+[https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html)
+
+```php
+\Spatie\ElasticsearchQueryBuilder\Queries\PercolateQuery::create('query', ['title' => 'foo', 'body' => 'bar']);
+```
+
 #### `BoolQuery`
 
 [https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html)

--- a/src/Queries/PercolateQuery.php
+++ b/src/Queries/PercolateQuery.php
@@ -2,30 +2,65 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Queries;
 
+use Exception;
+
 class PercolateQuery implements Query
 {
     protected string $field;
-
     protected array $document;
+    protected string $index;
+    protected string $id;
 
-    public static function create(string $field, array $document): static
+    public static function create(string $field): static
     {
-        return new self($field, $document);
+        return new self($field);
     }
 
-    public function __construct(string $field, array $document)
+    public function __construct(string $field)
     {
         $this->field = $field;
+    }
+
+    public function setInlineDocument(array $document): static
+    {
         $this->document = $document;
+
+        return $this;
+    }
+
+    public function setDocument(string $index, string|int $id): static
+    {
+        $this->index = $index;
+        $this->id = (string) $id;
+
+        return $this;
     }
 
     public function toArray(): array
     {
-        return [
+        if(isset($this->document) && isset($this->index)) {
+            throw new Exception('You can only set an inline document or a document, not both.');
+        }
+
+        if (!isset($this->document) && !isset($this->index)) {
+            throw new Exception('You must set an inline document or a document.');
+        }
+
+        $query = [
             'percolate' => [
                 'field' => $this->field,
-                'document' => $this->document,
             ],
         ];
+
+        if (isset($this->document)) {
+            $query['percolate']['document'] = $this->document;
+
+            return $query;
+        }
+
+        $query['percolate']['index'] = $this->index;
+        $query['percolate']['id'] = $this->id;
+
+        return $query;
     }
 }

--- a/src/Queries/PercolateQuery.php
+++ b/src/Queries/PercolateQuery.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Queries;
+
+class PercolateQuery implements Query
+{
+    protected string $field;
+
+    protected array $document;
+
+    public static function create(string $field, array $document): static
+    {
+        return new self($field, $document);
+    }
+
+    public function __construct(string $field, array $document)
+    {
+        $this->field = $field;
+        $this->document = $document;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'percolate' => [
+                'field' => $this->field,
+                'document' => $this->document,
+            ],
+        ];
+    }
+}

--- a/tests/Queries/PercolateQueryTest.php
+++ b/tests/Queries/PercolateQueryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
 

--- a/tests/Queries/PercolateQueryTest.php
+++ b/tests/Queries/PercolateQueryTest.php
@@ -4,14 +4,23 @@ declare(strict_types=1);
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use Spatie\ElasticsearchQueryBuilder\Queries\PercolateQuery;
 
 final class PercolateQueryTest extends TestCase
 {
-    public function testToArrayBuildsCorrectQuery(): void
+    public function testCreateReturnsNewInstance(): void
     {
-        $query = new PercolateQuery('test_field', ['foo' => 'bar', 'baz' => 'qux']);
+        $query = PercolateQuery::create('test_field');
+
+        self::assertInstanceOf(PercolateQuery::class, $query);
+    }
+
+    public function testInlineDocumentToArrayBuildsCorrectQuery(): void
+    {
+        $query = (new PercolateQuery('test_field'))
+            ->setInlineDocument(['foo' => 'bar', 'baz' => 'qux']);
 
         self::assertEquals([
             'percolate' => [
@@ -19,5 +28,38 @@ final class PercolateQueryTest extends TestCase
                 'document' => ['foo' => 'bar', 'baz' => 'qux'],
             ],
         ], $query->toArray());
+    }
+
+    public function testDocumentToArrayBuildsCorrectQuery(): void
+    {
+        $query = (new PercolateQuery('test_field'))
+            ->setDocument('test_index', 123);
+
+        self::assertEquals([
+            'percolate' => [
+                'field' => 'test_field',
+                'index' => 'test_index',
+                'id' => '123',
+            ],
+        ], $query->toArray());
+    }
+
+    public function testToArrayThrowsExceptionWhenBothInlineDocumentAndDocumentAreSet(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('You can only set an inline document or a document, not both.');
+
+        (new PercolateQuery('test_field'))
+            ->setInlineDocument(['foo' => 'bar', 'baz' => 'qux'])
+            ->setDocument('test_index', 123)
+            ->toArray();
+    }
+
+    public function testToArrayThrowsExceptionWhenNeitherInlineDocumentNorDocumentAreSet(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('You must set an inline document or a document.');
+
+        (new PercolateQuery('test_field'))->toArray();
     }
 }

--- a/tests/Queries/PercolateQueryTest.php
+++ b/tests/Queries/PercolateQueryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Queries\PercolateQuery;
+
+final class PercolateQueryTest extends TestCase
+{
+    public function testToArrayBuildsCorrectQuery(): void
+    {
+        $query = new PercolateQuery('test_field', ['foo' => 'bar', 'baz' => 'qux']);
+
+        self::assertEquals([
+            'percolate' => [
+                'field' => 'test_field',
+                'document' => ['foo' => 'bar', 'baz' => 'qux'],
+            ],
+        ], $query->toArray());
+    }
+}

--- a/tests/Queries/PercolateQueryTest.php
+++ b/tests/Queries/PercolateQueryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
 
 use Exception;

--- a/tests/Queries/PercolateQueryTest.php
+++ b/tests/Queries/PercolateQueryTest.php
@@ -7,7 +7,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use Spatie\ElasticsearchQueryBuilder\Queries\PercolateQuery;
 
-final class PercolateQueryTest extends TestCase
+class PercolateQueryTest extends TestCase
 {
     public function testCreateReturnsNewInstance(): void
     {


### PR DESCRIPTION
This PR adds support for the [percolate query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html).