### PR TITLE
Support operator in MatchQuery

### DIFF
--- a/src/Queries/MatchQuery.php
+++ b/src/Queries/MatchQuery.php
@@ -8,7 +8,8 @@ class MatchQuery implements Query
         string $field,
         string | int $query,
         null | string | int $fuzziness = null,
-        null | float $boost = null
+        null | float $boost = null,
+        null | string $operator = 'or'
     ): self {
         return new self($field, $query, $fuzziness, $boost);
     }
@@ -17,7 +18,8 @@ class MatchQuery implements Query
         protected string $field,
         protected string | int $query,
         protected null | string | int $fuzziness = null,
-        protected null | float $boost = null
+        protected null | float $boost = null,
+        protected null | string $operator = 'or'
     ) {
     }
 
@@ -37,6 +39,10 @@ class MatchQuery implements Query
 
         if ($this->boost) {
             $match['match'][$this->field]['boost'] = $this->boost;
+        }
+
+        if ($this->operator) {
+            $match['match'][$this->field]['operator'] = $this->operator;
         }
 
         return $match;


### PR DESCRIPTION
The default operator for a MatchQuery is 'OR'. There's a difference between combining fuzziness with an operator. For example, fuzziness set to 1 with the 'OR' operator will fetch all documents, even those with a score of 0, while the 'AND' operator will only return documents with a certain minimum score (in my case, greater than 3).