### PR TITLE
Fix missing args for create func

### DIFF
--- a/src/Exceptions/InvalidOperatorValue.php
+++ b/src/Exceptions/InvalidOperatorValue.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Queries;
+
+use Spatie\ElasticsearchQueryBuilder\Exceptions\InvalidOperatorValue;
+
+class MatchQuery implements Query
+{
+    protected const VALID_OPERATORS = ['and', 'or'];
+
+    public static function create(
+        string $field,
+        string | int $query,
+        null | string | int $fuzziness = null,
+        null | float $boost = null,
+        null | string $operator = 'or'
+    ): self {
+        return new self($field, $query, $fuzziness, $boost, $operator);
+    }
+
+    public function __construct(
+        protected string $field,
+        protected string | int $query,
+        protected null | string | int $fuzziness = null,
+        protected null | float $boost = null,
+        protected null | string $operator = 'or'
+    ) {
+        if (! in_array(strtolower($operator), self::VALID_OPERATORS)) {
+            throw new InvalidOperatorValue;
+        }
+    }
+
+    public function toArray(): array
+    {
+        $match = [
+            'match' => [
+                $this->field => [
+                    'query' => $this->query,
+                ],
+            ],
+        ];
+
+        if ($this->fuzziness) {
+            $match['match'][$this->field]['fuzziness'] = $this->fuzziness;
+        }
+
+        if ($this->boost) {
+            $match['match'][$this->field]['boost'] = $this->boost;
+        }
+
+        if ($this->operator) {
+            $match['match'][$this->field]['operator'] = $this->operator;
+        }
+
+        return $match;
+    }
+}

--- a/src/Exceptions/InvalidOperatorValue.php
+++ b/src/Exceptions/InvalidOperatorValue.php
@@ -1,57 +1,13 @@
 <?php
 
-namespace Spatie\ElasticsearchQueryBuilder\Queries;
+namespace Spatie\ElasticsearchQueryBuilder\Exceptions;
 
-use Spatie\ElasticsearchQueryBuilder\Exceptions\InvalidOperatorValue;
+use InvalidArgumentException;
 
-class MatchQuery implements Query
+class InvalidOperatorValue extends InvalidArgumentException
 {
-    protected const VALID_OPERATORS = ['and', 'or'];
-
-    public static function create(
-        string $field,
-        string | int $query,
-        null | string | int $fuzziness = null,
-        null | float $boost = null,
-        null | string $operator = 'or'
-    ): self {
-        return new self($field, $query, $fuzziness, $boost, $operator);
-    }
-
-    public function __construct(
-        protected string $field,
-        protected string | int $query,
-        protected null | string | int $fuzziness = null,
-        protected null | float $boost = null,
-        protected null | string $operator = 'or'
-    ) {
-        if (! in_array(strtolower($operator), self::VALID_OPERATORS)) {
-            throw new InvalidOperatorValue;
-        }
-    }
-
-    public function toArray(): array
+    public function __construct()
     {
-        $match = [
-            'match' => [
-                $this->field => [
-                    'query' => $this->query,
-                ],
-            ],
-        ];
-
-        if ($this->fuzziness) {
-            $match['match'][$this->field]['fuzziness'] = $this->fuzziness;
-        }
-
-        if ($this->boost) {
-            $match['match'][$this->field]['boost'] = $this->boost;
-        }
-
-        if ($this->operator) {
-            $match['match'][$this->field]['operator'] = $this->operator;
-        }
-
-        return $match;
+        parent::__construct('The operator must be either "or" or "and".');
     }
 }

--- a/src/Queries/MatchQuery.php
+++ b/src/Queries/MatchQuery.php
@@ -11,7 +11,7 @@ class MatchQuery implements Query
         null | float $boost = null,
         null | string $operator = 'or'
     ): self {
-        return new self($field, $query, $fuzziness, $boost);
+        return new self($field, $query, $fuzziness, $boost, $operator);
     }
 
     public function __construct(

--- a/src/Queries/MatchQuery.php
+++ b/src/Queries/MatchQuery.php
@@ -2,8 +2,12 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Queries;
 
+use Spatie\ElasticsearchQueryBuilder\Exceptions\InvalidOperatorValue;
+
 class MatchQuery implements Query
 {
+    protected const VALID_OPERATORS = ['and', 'or'];
+
     public static function create(
         string $field,
         string | int $query,
@@ -21,6 +25,9 @@ class MatchQuery implements Query
         protected null | float $boost = null,
         protected null | string $operator = 'or'
     ) {
+        if (! in_array(strtolower($operator), self::VALID_OPERATORS)) {
+            throw new InvalidOperatorValue;
+        }
     }
 
     public function toArray(): array

--- a/tests/Queries/MatchQueryTest.php
+++ b/tests/Queries/MatchQueryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Exceptions\InvalidOperatorValue;
+use Spatie\ElasticsearchQueryBuilder\Queries\MatchQuery;
+
+class MatchQueryTest extends TestCase
+{
+    public function testCreateReturnsNewInstance(): void
+    {
+        $query = MatchQuery::create('test_field', 'test_value');
+
+        self::assertInstanceOf(MatchQuery::class, $query);
+    }
+
+    public function testDefaultSetup(): void
+    {
+        $query = (new MatchQuery('test_field', 'test_value'));
+
+        self::assertEquals([
+            'match' => [
+                'test_field' => [
+                    'query' => 'test_value',
+                    'operator' => 'or',
+                ],
+            ],
+        ], $query->toArray());
+    }
+
+    public function testFullSetup(): void
+    {
+        $query = (new MatchQuery(
+            field: 'test_field',
+            query: 'test_value',
+            fuzziness: 'auto',
+            boost: 1,
+            operator: 'and'
+        ));
+
+        self::assertEquals([
+            'match' => [
+                'test_field' => [
+                    'query' => 'test_value',
+                    'fuzziness' => 'auto',
+                    'boost' => 1,
+                    'operator' => 'and',
+                ],
+            ],
+        ], $query->toArray());
+    }
+
+    public function testSetupWithStaticCreateFunction(): void
+    {
+        $query = MatchQuery::create(
+            field: 'test_field',
+            query: 'test_value',
+            fuzziness: 'auto',
+            boost: 1,
+            operator: 'and'
+        );
+
+        self::assertEquals([
+            'match' => [
+                'test_field' => [
+                    'query' => 'test_value',
+                    'fuzziness' => 'auto',
+                    'boost' => 1,
+                    'operator' => 'and',
+                ],
+            ],
+        ], $query->toArray());
+    }
+
+    public function testToThrowsExceptionWhenProvideWrongTypeOfOperator(): void
+    {
+        $this->expectException(InvalidOperatorValue::class);
+        $this->expectExceptionMessage('The operator must be either "or" or "and".');
+
+        MatchQuery::create(
+            field: 'test_field',
+            query: 'test_value',
+            operator: 1
+        );
+    }
+}


### PR DESCRIPTION
I'm really sorry, I made mistake forgotting to add $operator to static `create` function in https://github.com/spatie/elasticsearch-query-builder/pull/59. We can still using the construct class for right result but should fix the create as well
 ![image](https://github.com/user-attachments/assets/643565e6-be87-4d26-83e4-24cc81208392)