### PR TITLE
Add `multi_terms` aggregation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,21 @@ The following query types are available:
     ->aggregation(/* $subAggregation */);
 ```
 
+#### `MultiTermsAggregation`
+
+[https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-multi-terms-aggregation.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-multi-terms-aggregation.html)
+
+```php
+\Spatie\ElasticsearchQueryBuilder\Aggregations\MultiTermsAggregation::create(
+    'categories',
+    ['category', 'subcategory']
+)
+    ->size(10)
+    ->order(['_count' => 'asc'])
+    ->missing('N/A')
+    ->aggregation(/* $subAggregation */);
+```
+
 #### `TopHitsAggregation`
 
 [https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html)

--- a/src/Aggregations/MultiTermsAggregation.php
+++ b/src/Aggregations/MultiTermsAggregation.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Aggregations;
+
+use Spatie\ElasticsearchQueryBuilder\AggregationCollection;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\Concerns\WithAggregations;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\Concerns\WithMissing;
+
+class MultiTermsAggregation extends Aggregation
+{
+    use WithMissing;
+    use WithAggregations;
+
+    /** @var string[]  */
+    protected array $fields;
+
+    protected ?int $size = null;
+
+    protected ?array $order = null;
+
+    /**
+     * @param  string  $name
+     * @param  string[]  $fields
+     * @return self
+     */
+    public static function create(string $name, array $fields): self
+    {
+        return new self($name, $fields);
+    }
+
+    public function __construct(string $name, array $fields)
+    {
+        $this->name = $name;
+        $this->fields = $fields;
+        $this->aggregations = new AggregationCollection();
+    }
+
+    public function size(int $size): self
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function order(array $order): self
+    {
+        $this->order = $order;
+
+        return $this;
+    }
+
+    public function payload(): array
+    {
+        $terms = [];
+        foreach($this->fields as $field) {
+            $terms[] = ['field' => $field];
+        }
+        $parameters = [
+            'terms' => $terms,
+        ];
+
+        if ($this->size) {
+            $parameters['size'] = $this->size;
+        }
+
+        if ($this->missing) {
+            $parameters['missing'] = $this->missing;
+        }
+
+        if ($this->order) {
+            $parameters['order'] = $this->order;
+        }
+
+        $aggregation = [
+            'multi_terms' => $parameters,
+        ];
+
+        if (! $this->aggregations->isEmpty()) {
+            $aggregation['aggs'] = $this->aggregations->toArray();
+        }
+
+        return $aggregation;
+    }
+}

--- a/tests/Aggregations/MultiTermsAggregationTest.php
+++ b/tests/Aggregations/MultiTermsAggregationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Aggregations;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\MultiTermsAggregation;
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Builder;
+
+class MultiTermsAggregationTest extends TestCase
+{
+    private Client $client;
+
+    protected function setUp(): void
+    {
+        $this->client = ClientBuilder::create()->build();
+    }
+
+    public function testMultiTermsAggregation(): void
+    {
+        $builder = new Builder($this->client);
+
+        $aggregation = MultiTermsAggregation::create('agg_name', ['field1', 'field2']);
+
+        $expectedAggArray = [
+            'multi_terms' => [
+                'terms' => [
+                    ['field' => 'field1'],
+                    ['field' => 'field2']
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedAggArray, $aggregation->toArray());
+
+        $builder->addAggregation($aggregation);
+
+        $expectedBuilderPayload = [
+            'aggs' => [
+                'agg_name' => $expectedAggArray,
+            ]
+        ];
+
+        $this->assertEquals($expectedBuilderPayload, $builder->getPayload());
+    }
+}


### PR DESCRIPTION
As mentioned in https://github.com/spatie/elasticsearch-query-builder/discussions/62

Add a `MultiTermsAggregation` that mostly follows the `TermsAggregation`, but accepts an array of field names and generates an appropriate payload.