### PR TITLE
Add MultiBuilder to support multi-search API 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "require-dev": {
         "elasticsearch/elasticsearch": "^8.0",
         "friendsofphp/php-cs-fixer": "^2.17",
+        "php-http/mock-client": "^1.5",
         "phpunit/phpunit": "^9.5",
         "spatie/ray": "^1.10",
         "vimeo/psalm": "^4.3"

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -107,6 +107,11 @@ class Builder
         return $this;
     }
 
+    public function getIndex(): ?string
+    {
+        return $this->searchIndex;
+    }
+
     public function trackTotalHits(bool $value = true): static
     {
         $this->trackTotalHits = $value;

--- a/src/MultiBuilder.php
+++ b/src/MultiBuilder.php
@@ -29,8 +29,7 @@ class MultiBuilder
     {
         $payload = [];
         foreach ($this->builders as $builderInstance) {
-            $index = $builderInstance['index'];
-            $builder = $builderInstance['builder'];
+            ['index' => $index, 'builder' => $builder] = $builderInstance;
             $payload[] = $index ? ['index' => $index] : [];
             $payload[] = $builder->getPayload();
         }

--- a/src/MultiBuilder.php
+++ b/src/MultiBuilder.php
@@ -16,7 +16,6 @@ class MultiBuilder
 
     public function addBuilder(Builder $builder, ?string $indexName = null): static
     {
-        // if we have a name, use the key, else just let is use numeric indices
         $this->builders[] = [
             'index' => $indexName ?? $builder->getIndex(),
             'builder' => $builder,
@@ -28,11 +27,13 @@ class MultiBuilder
     public function getPayload(): array
     {
         $payload = [];
+
         foreach ($this->builders as $builderInstance) {
             ['index' => $index, 'builder' => $builder] = $builderInstance;
             $payload[] = $index ? ['index' => $index] : [];
             $payload[] = $builder->getPayload();
         }
+
         return $payload;
     }
 

--- a/src/MultiBuilder.php
+++ b/src/MultiBuilder.php
@@ -37,7 +37,7 @@ class MultiBuilder
         return $payload;
     }
 
-    public function multiSearch(): Elasticsearch|Promise
+    public function search(): Elasticsearch|Promise
     {
         $payload = $this->getPayload();
 

--- a/src/MultiBuilder.php
+++ b/src/MultiBuilder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use Http\Promise\Promise;
+
+class MultiBuilder
+{
+    protected ?array $builders = [];
+
+    public function __construct(protected Client $client)
+    {
+    }
+
+    public function addBuilder(Builder $builder, ?string $indexName = null): static
+    {
+        // if we have a name, use the key, else just let is use numeric indices
+        $this->builders[] = [
+            'index' => $indexName ?? $builder->getIndex(),
+            'builder' => $builder,
+        ];
+
+        return $this;
+    }
+
+    public function getPayload(): array
+    {
+        $payload = [];
+        foreach ($this->builders as $builderInstance) {
+            $index = $builderInstance['index'];
+            $builder = $builderInstance['builder'];
+            $payload[] = $index ? ['index' => $index] : [];
+            $payload[] = $builder->getPayload();
+        }
+        return $payload;
+    }
+
+    public function multiSearch(): Elasticsearch|Promise
+    {
+        $payload = $this->getPayload();
+
+        $params = [
+            'body' => $payload,
+        ];
+
+        return $this->client->msearch($params);
+    }
+}

--- a/tests/Builders/MultiBuilderTest.php
+++ b/tests/Builders/MultiBuilderTest.php
@@ -4,11 +4,9 @@ namespace Spatie\ElasticsearchQueryBuilder\Tests\Builders;
 
 use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\ClientBuilder;
-use PhpParser\Node\Expr\AssignOp\Mul;
 use Spatie\ElasticsearchQueryBuilder\Builder;
 use Spatie\ElasticsearchQueryBuilder\MultiBuilder;
 use PHPUnit\Framework\TestCase;
-use Spatie\ElasticsearchQueryBuilder\Queries\MatchQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\TermQuery;
 
 class MultiBuilderTest extends TestCase

--- a/tests/Builders/MultiBuilderTest.php
+++ b/tests/Builders/MultiBuilderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Builders;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
+use PhpParser\Node\Expr\AssignOp\Mul;
+use Spatie\ElasticsearchQueryBuilder\Builder;
+use Spatie\ElasticsearchQueryBuilder\MultiBuilder;
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Queries\MatchQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\TermQuery;
+
+class MultiBuilderTest extends TestCase
+{
+    private MultiBuilder $multiBuilder;
+
+    private Client $client;
+
+    protected function setUp(): void
+    {
+        $this->client = ClientBuilder::create()->build();
+
+        $this->multiBuilder = new MultiBuilder($this->client);
+    }
+
+    public function testEmptyPayloadGeneratesCorrectly(): void
+    {
+        $this->assertEmpty($this->multiBuilder->getPayload());
+    }
+
+    public function testSingleBuilderPayloadGeneratesCorrectly(): void
+    {
+        $this->multiBuilder->addBuilder(
+            (new Builder($this->client))
+                ->addQuery(TermQuery::create('test', 'value'))
+        );
+        $payload = $this->multiBuilder->getPayload();
+        $this->assertNotEmpty($payload);
+        $this->assertCount(2, $payload);
+        $this->assertEquals([], $payload[0]);
+        $this->assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        ['term' => ['test' => 'value']],
+                    ],
+                ],
+            ],
+        ], $payload[1]);
+    }
+
+    public function testMultipleBuilderPayloadGeneratesCorrectly(): void
+    {
+        $this->multiBuilder->addBuilder(
+            (new Builder($this->client))
+                ->index('firstIndex')
+                ->addQuery(TermQuery::create('keyword', 'value'), 'filter'),
+        );
+        $this->multiBuilder->addBuilder(
+            (new Builder($this->client))
+                ->addQuery(TermQuery::create('keyword', 'value'), 'filter'),
+            'secondIndex'
+        );
+
+        $payload = $this->multiBuilder->getPayload();
+
+        $this->assertNotEmpty($payload);
+        $this->assertCount(4, $payload);
+
+        $index = $payload[0];
+        $this->assertEquals(['index' => 'firstIndex'], $index);
+
+        $body = $payload[1];
+        $this->assertEquals([
+            'query' => [
+                'bool' => [
+                    'filter' => [['term' => ['keyword' => 'value']]],
+                ],
+            ],
+        ], $body);
+
+        $index = $payload[2];
+        $this->assertEquals(['index' => 'secondIndex'], $index);
+
+        $body = $payload[3];
+        $this->assertEquals([
+            'query' => [
+                'bool' => [
+                    'filter' => [['term' => ['keyword' => 'value']]],
+                ],
+            ],
+        ], $body);
+    }
+}


### PR DESCRIPTION
As mentioned in https://github.com/spatie/elasticsearch-query-builder/discussions/61

Support the ES `_msearch` query API, to run multiple queries in one request.

- add getIndex method to Builder, need to extract for the multisearch body if not specified
- create MultiBuilder class following the Builder patterns
- `multiSearch` method runs the `msearch` method in ES PHP