### PR TITLE
Collapse: Make use of nested inner hits query object

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -7,6 +7,7 @@ use Elastic\Elasticsearch\Response\Elasticsearch;
 use Http\Promise\Promise;
 use Spatie\ElasticsearchQueryBuilder\Aggregations\Aggregation;
 use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
 use Spatie\ElasticsearchQueryBuilder\Queries\Query;
 use Spatie\ElasticsearchQueryBuilder\Sorts\Sorting;
 
@@ -174,11 +175,14 @@ class Builder
         return $this;
     }
 
-    public function collapse(string $field, ?array $innerHits = null, ?int $maxConcurrentGroupRequests = null): static
+    public function collapse(string $field, array|InnerHits|null $innerHits = null, ?int $maxConcurrentGroupRequests = null): static
     {
         $this->collapse = ['field' => $field];
 
         if ($innerHits) {
+            if ($innerHits instanceof InnerHits) {
+                $innerHits = $innerHits->toArray();
+            }
             $this->collapse['inner_hits'] = $innerHits;
         }
 

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Builders;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Transport\TransportBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Spatie\ElasticsearchQueryBuilder\Builder;
+use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
+use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;
+
+class BuilderTest extends TestCase
+{
+    protected Client $client;
+
+    public function setUp(): void
+    {
+        $transport = TransportBuilder::create()
+            ->setClient(new \Http\Mock\Client())
+            ->build();
+
+        $logger = $this->createStub(LoggerInterface::class);
+
+        $this->client = new Client($transport, $logger);
+    }
+
+    public function testGeneratesCollapseWithPlainArrayData(): void
+    {
+        $innerHits = [
+            'name' => 'first_group',
+            'size' => 1,
+            'sort' => [
+                [ 'name.keyword' => [ 'order' => 'asc' ] ],
+            ],
+        ];
+
+        $builder = (new Builder($this->client))
+            ->collapse('group_id', $innerHits);
+
+        self::assertEquals(
+            [ 'collapse' => [ 'field' => 'group_id', 'inner_hits' => $innerHits ] ],
+            $builder->getPayload()
+        );
+    }
+
+    public function testGeneratesCollapseWithInnerHitsObject(): void
+    {
+        $innerHits = InnerHits::create('first_group')
+            ->size(1)
+            ->addSort(new Sort('name.keyword', 'asc'));
+
+        $builder = (new Builder($this->client))
+            ->collapse('group_id', $innerHits);
+
+        self::assertEquals(
+            [
+                'collapse' => [
+                    'field' => 'group_id', 'inner_hits' => [
+                        'name' => 'first_group',
+                        'size' => 1,
+                        'sort' => [
+                            [
+                                'name.keyword' => [
+                                    'order' => 'asc',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getPayload()
+        );
+    }
+}


### PR DESCRIPTION
"Collapse" was a great addition in 3.5.0.
However, it did not follow the pattern of "pass an object, serialize later" used in the other classes, but required an array representation.
This change here allows usage of an "InnerHits" object (array type hint was left to assure backwards compatibility).