### PR TITLE
Decouple `Builder` from `Elastic\Elasticsearch\Client`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,7 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "elasticsearch/elasticsearch": "^8.0",
         "friendsofphp/php-cs-fixer": "^2.17",
-        "php-http/mock-client": "^1.5",
         "phpunit/phpunit": "^9.5",
         "spatie/ray": "^1.10",
         "vimeo/psalm": "^4.3"

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -2,9 +2,6 @@
 
 namespace Spatie\ElasticsearchQueryBuilder;
 
-use Elastic\Elasticsearch\Client;
-use Elastic\Elasticsearch\Response\Elasticsearch;
-use Http\Promise\Promise;
 use Spatie\ElasticsearchQueryBuilder\Aggregations\Aggregation;
 use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
@@ -41,7 +38,7 @@ class Builder
 
     protected ?array $collapse = null;
 
-    public function __construct(protected Client $client)
+    public function __construct()
     {
     }
 
@@ -78,7 +75,7 @@ class Builder
         return $this;
     }
 
-    public function search(): Elasticsearch|Promise
+    public function params(): array
     {
         $payload = $this->getPayload();
 
@@ -102,7 +99,7 @@ class Builder
             $params['track_total_hits'] = true;
         }
 
-        return $this->client->search($params);
+        return $params;
     }
 
     public function index(string $searchIndex): static

--- a/src/MultiBuilder.php
+++ b/src/MultiBuilder.php
@@ -2,17 +2,9 @@
 
 namespace Spatie\ElasticsearchQueryBuilder;
 
-use Elastic\Elasticsearch\Client;
-use Elastic\Elasticsearch\Response\Elasticsearch;
-use Http\Promise\Promise;
-
 class MultiBuilder
 {
     protected ?array $builders = [];
-
-    public function __construct(protected Client $client)
-    {
-    }
 
     public function addBuilder(Builder $builder, ?string $indexName = null): static
     {
@@ -37,7 +29,7 @@ class MultiBuilder
         return $payload;
     }
 
-    public function search(): Elasticsearch|Promise
+    public function params(): array
     {
         $payload = $this->getPayload();
 
@@ -45,6 +37,6 @@ class MultiBuilder
             'body' => $payload,
         ];
 
-        return $this->client->msearch($params);
+        return $params;
     }
 }

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Builders;
 
-use Elastic\Elasticsearch\Client;
-use Elastic\Transport\TransportBuilder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Spatie\ElasticsearchQueryBuilder\Builder;
@@ -12,19 +10,6 @@ use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;
 
 class BuilderTest extends TestCase
 {
-    protected Client $client;
-
-    public function setUp(): void
-    {
-        $transport = TransportBuilder::create()
-            ->setClient(new \Http\Mock\Client())
-            ->build();
-
-        $logger = $this->createStub(LoggerInterface::class);
-
-        $this->client = new Client($transport, $logger);
-    }
-
     public function testGeneratesCollapseWithPlainArrayData(): void
     {
         $innerHits = [
@@ -35,7 +20,7 @@ class BuilderTest extends TestCase
             ],
         ];
 
-        $builder = (new Builder($this->client))
+        $builder = (new Builder())
             ->collapse('group_id', $innerHits);
 
         self::assertEquals(
@@ -50,7 +35,7 @@ class BuilderTest extends TestCase
             ->size(1)
             ->addSort(new Sort('name.keyword', 'asc'));
 
-        $builder = (new Builder($this->client))
+        $builder = (new Builder())
             ->collapse('group_id', $innerHits);
 
         self::assertEquals(
@@ -75,7 +60,7 @@ class BuilderTest extends TestCase
 
     public function testMinScoreIsAppliedToThePayload(): void
     {
-        $payload = (new Builder($this->client))
+        $payload = (new Builder())
             ->minScore(0.1)
             ->getPayload();
 

--- a/tests/Builders/MultiBuilderTest.php
+++ b/tests/Builders/MultiBuilderTest.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Builders;
 
-use Elastic\Elasticsearch\Client;
-use Elastic\Transport\TransportBuilder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Spatie\ElasticsearchQueryBuilder\Builder;
@@ -18,15 +16,7 @@ class MultiBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        $transport = TransportBuilder::create()
-            ->setClient(new \Http\Mock\Client())
-            ->build();
-
-        $logger = $this->createStub(LoggerInterface::class);
-
-        $this->client = new Client($transport, $logger);
-
-        $this->multiBuilder = new MultiBuilder($this->client);
+        $this->multiBuilder = new MultiBuilder();
     }
 
     public function testEmptyPayloadGeneratesCorrectly(): void
@@ -37,7 +27,7 @@ class MultiBuilderTest extends TestCase
     public function testSingleBuilderPayloadGeneratesCorrectly(): void
     {
         $this->multiBuilder->addBuilder(
-            (new Builder($this->client))->addQuery(TermQuery::create('test', 'value'))
+            (new Builder())->addQuery(TermQuery::create('test', 'value'))
         );
 
         $payload = $this->multiBuilder->getPayload();
@@ -62,12 +52,12 @@ class MultiBuilderTest extends TestCase
     public function testMultipleBuilderPayloadGeneratesCorrectly(): void
     {
         $this->multiBuilder->addBuilder(
-            (new Builder($this->client))
+            (new Builder())
                 ->index('firstIndex')
                 ->addQuery(TermQuery::create('keyword', 'value'), 'filter'),
         );
         $this->multiBuilder->addBuilder(
-            (new Builder($this->client))
+            (new Builder())
                 ->addQuery(TermQuery::create('keyword', 'value'), 'filter'),
             'secondIndex'
         );

--- a/tests/Queries/CollapseTest.php
+++ b/tests/Queries/CollapseTest.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
 
-use Elastic\Elasticsearch\Client;
-use Elastic\Transport\TransportBuilder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Spatie\ElasticsearchQueryBuilder\Builder;
@@ -13,19 +11,9 @@ class CollapseTest extends TestCase
 
     private Builder $builder;
 
-    private Client $client;
-
     protected function setUp(): void
     {
-        $transport = TransportBuilder::create()
-            ->setClient(new \Http\Mock\Client())
-            ->build();
-
-        $logger = $this->createStub(LoggerInterface::class);
-
-        $this->client = new Client($transport, $logger);
-
-        $this->builder = new Builder($this->client);
+        $this->builder = new Builder();
     }
 
     public function testCollapseIsAddedToPayload()


### PR DESCRIPTION
This PR decouples `Builder` from `Elastic\Elasticsearch\Client`. `Builder::search` is replaced with `Builder::params`, returning an array that can then be passed directly to `Elastic\Elasticsearch\Client::search`.

The rationale behind this change is that I'd like to build a query in a method that does not have access to my instance of `Elastic\Elasticsearch\Client`. The result of this method will ultimately get passed to where I do have my `$client`. I'd like to avoid having to pass around `$client` everywhere I use the query builder.

I see building a query and executing it as two separate concerns.

Please feel free to reject this change. I understand this is a _major_ backwards compatibility break and would require a new major version. Probably not a change there will be any interest in, but nonetheless, I figured I'd open up a PR just in case.