### PR TITLE
Add operator, boost, prefix length, and max expansions to MultiMatchQuery

### DIFF
--- a/src/Queries/MultiMatchQuery.php
+++ b/src/Queries/MultiMatchQuery.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\ElasticsearchQueryBuilder\Queries;
 
+use Spatie\ElasticsearchQueryBuilder\Exceptions\InvalidOperatorValue;
+
 class MultiMatchQuery implements Query
 {
     public const TYPE_BEST_FIELDS = 'best_fields';
@@ -10,22 +12,34 @@ class MultiMatchQuery implements Query
     public const TYPE_PHRASE = 'phrase';
     public const TYPE_PHRASE_PREFIX = 'phrase_prefix';
     public const TYPE_BOOL_PREFIX = 'bool_prefix';
+    protected const VALID_OPERATORS = ['and', 'or'];
 
     public static function create(
         string $query,
         array $fields,
         int | string | null $fuzziness = null,
-        ?string $type = null
+        string | null $type = null,
+        string | null $operator = null,
+        float | null $boost = null,
+        int | null $prefixLength = null,
+        int | null $maxExpansions = null,
     ): static {
-        return new self($query, $fields, $fuzziness, $type);
+        return new self($query, $fields, $fuzziness, $type, $operator, $boost, $prefixLength, $maxExpansions);
     }
 
     public function __construct(
         protected string $query,
         protected array $fields,
         protected int | string | null $fuzziness = null,
-        protected ?string $type = null
+        protected string | null $type = null,
+        protected string | null $operator = null,
+        protected float | null $boost = null,
+        protected int | null $prefixLength = null,
+        protected int | null $maxExpansions = null,
     ) {
+        if ($operator && ! in_array(strtolower($operator), self::VALID_OPERATORS)) {
+            throw new InvalidOperatorValue;
+        }
     }
 
     public function toArray(): array
@@ -43,6 +57,22 @@ class MultiMatchQuery implements Query
 
         if ($this->type) {
             $multiMatch['multi_match']['type'] = $this->type;
+        }
+
+        if ($this->operator) {
+            $multiMatch['multi_match']['operator'] = $this->operator;
+        }
+
+        if ($this->boost !== null) {
+            $multiMatch['multi_match']['boost'] = $this->boost;
+        }
+
+        if ($this->prefixLength !== null) {
+            $multiMatch['multi_match']['prefix_length'] = $this->prefixLength;
+        }
+
+        if ($this->maxExpansions !== null) {
+            $multiMatch['multi_match']['max_expansions'] = $this->maxExpansions;
         }
 
         return $multiMatch;

--- a/tests/Queries/MultiMatchQueryTest.php
+++ b/tests/Queries/MultiMatchQueryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Queries;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Exceptions\InvalidOperatorValue;
+use Spatie\ElasticsearchQueryBuilder\Queries\MultiMatchQuery;
+
+final class MultiMatchQueryTest extends TestCase
+{
+    public function testCreateReturnsNewInstance(): void
+    {
+        $query = MultiMatchQuery::create('test_value', ['field1', 'field2']);
+
+        self::assertInstanceOf(MultiMatchQuery::class, $query);
+    }
+
+    public function testDefaultSetup(): void
+    {
+        $query = (new MultiMatchQuery('test_value', ['field1', 'field2']));
+
+        self::assertEquals([
+            'multi_match' => [
+                'query' => 'test_value',
+                'fields' => ['field1', 'field2'],
+            ],
+        ], $query->toArray());
+    }
+
+    public function testFullSetup(): void
+    {
+        $query = (new MultiMatchQuery(
+            query: 'test_value',
+            fields: ['field1', 'field2'],
+            fuzziness: 'auto',
+            type: MultiMatchQuery::TYPE_PHRASE,
+            operator: 'and',
+            boost: 1.5,
+            prefixLength: 1,
+            maxExpansions: 50,
+        ));
+
+        self::assertEquals([
+            'multi_match' => [
+                'query' => 'test_value',
+                'fields' => ['field1', 'field2'],
+                'fuzziness' => 'auto',
+                'type' => 'phrase',
+                'operator' => 'and',
+                'boost' => 1.5,
+                'prefix_length' => 1,
+                'max_expansions' => 50,
+            ],
+        ], $query->toArray());
+    }
+
+    public function testSetupWithStaticCreateFunction(): void
+    {
+        $query = MultiMatchQuery::create(
+            query: 'test_value',
+            fields: ['field1', 'field2'],
+            fuzziness: 'auto',
+            type: MultiMatchQuery::TYPE_PHRASE,
+            operator: 'and',
+            boost: 1.5,
+            prefixLength: 1,
+            maxExpansions: 50,
+        );
+
+        self::assertEquals([
+            'multi_match' => [
+                'query' => 'test_value',
+                'fields' => ['field1', 'field2'],
+                'fuzziness' => 'auto',
+                'type' => 'phrase',
+                'operator' => 'and',
+                'boost' => 1.5,
+                'prefix_length' => 1,
+                'max_expansions' => 50,
+            ],
+        ], $query->toArray());
+    }
+
+    public function testInvalidOperatorThrowsException(): void
+    {
+        $this->expectException(InvalidOperatorValue::class);
+
+        new MultiMatchQuery(
+            query: 'test_value',
+            fields: ['field1', 'field2'],
+            operator: 'invalid_operator'
+        );
+    }
+}


### PR DESCRIPTION
This PR enhances the `MultiMatchQuery` class by adding new parameters. It also introduces a comprehensive test suite for the `MultiMatchQuery` class to ensure correctness and robustness, in line with the already existing `MatchQueryTest`.

### Enhancements to `MultiMatchQuery`:

* Added support for new parameters: `operator`, `boost`, `prefixLength`, and `maxExpansions`. These parameters allow more fine-grained control over the query behavior. I do feel the arguments are getting to a point that there are too many, especially when we would add even more. Ideally, this should be approached differently, but this would require some more discussion.