### PR TITLE
Fix missing parameter type restrictions in aggregations and sorts

### DIFF
--- a/src/Aggregations/CardinalityAggregation.php
+++ b/src/Aggregations/CardinalityAggregation.php
@@ -27,7 +27,7 @@ class CardinalityAggregation extends Aggregation
             'field' => $this->field,
         ];
 
-        if ($this->missing) {
+        if ($this->missing !== null) {
             $parameters['missing'] = $this->missing;
         }
 

--- a/src/Aggregations/Concerns/WithMissing.php
+++ b/src/Aggregations/Concerns/WithMissing.php
@@ -4,9 +4,9 @@ namespace Spatie\ElasticsearchQueryBuilder\Aggregations\Concerns;
 
 trait WithMissing
 {
-    protected ?string $missing = null;
+    protected string|int|float|bool|null $missing = null;
 
-    public function missing(string $missingValue): self
+    public function missing(string|int|float|bool $missingValue): self
     {
         $this->missing = $missingValue;
 

--- a/src/Aggregations/MaxAggregation.php
+++ b/src/Aggregations/MaxAggregation.php
@@ -27,7 +27,7 @@ class MaxAggregation extends Aggregation
             'field' => $this->field,
         ];
 
-        if ($this->missing) {
+        if ($this->missing !== null) {
             $parameters['missing'] = $this->missing;
         }
 

--- a/src/Aggregations/MinAggregation.php
+++ b/src/Aggregations/MinAggregation.php
@@ -27,7 +27,7 @@ class MinAggregation extends Aggregation
             'field' => $this->field,
         ];
 
-        if ($this->missing) {
+        if ($this->missing !== null) {
             $parameters['missing'] = $this->missing;
         }
 

--- a/src/Aggregations/SumAggregation.php
+++ b/src/Aggregations/SumAggregation.php
@@ -27,7 +27,7 @@ class SumAggregation extends Aggregation
             'field' => $this->field,
         ];
 
-        if ($this->missing) {
+        if ($this->missing !== null) {
             $parameters['missing'] = $this->missing;
         }
 

--- a/src/Aggregations/TermsAggregation.php
+++ b/src/Aggregations/TermsAggregation.php
@@ -53,7 +53,7 @@ class TermsAggregation extends Aggregation
             $parameters['size'] = $this->size;
         }
 
-        if ($this->missing) {
+        if ($this->missing !== null) {
             $parameters['missing'] = $this->missing;
         }
 

--- a/src/Sorts/Concerns/HasMissing.php
+++ b/src/Sorts/Concerns/HasMissing.php
@@ -4,9 +4,9 @@ namespace Spatie\ElasticsearchQueryBuilder\Sorts\Concerns;
 
 trait HasMissing
 {
-    protected ?string $missing = null;
+    protected string|int|float|bool|null $missing = null;
 
-    public function missing(string $missing): static
+    public function missing(string|int|float|bool $missing): static
     {
         $this->missing = $missing;
 

--- a/src/Sorts/NestedSort.php
+++ b/src/Sorts/NestedSort.php
@@ -61,23 +61,29 @@ class NestedSort implements Sorting
 
     public function toArray(): array
     {
+        $payload = array_filter(
+            [
+                'order' => $this->order,
+                'mode' => $this->mode,
+                'unmapped_type' => $this->unmappedType,
+                'nested' => array_filter(
+                    [
+                        'path' => $this->path,
+                        'filter' => $this->filter?->toArray(),
+                        'nested' => $this->nested?->toArray(),
+                        'max_children' => $this->maxChildren,
+                    ]
+                ),
+            ]
+        );
+
+        // missing can be empty string or zero value
+        if ($this->missing !== null) {
+            $payload['missing'] = $this->missing;
+        }
+
         return [
-            $this->field => array_filter(
-                [
-                    'order' => $this->order,
-                    'mode' => $this->mode,
-                    'missing' => $this->missing,
-                    'unmapped_type' => $this->unmappedType,
-                    'nested' => array_filter(
-                        [
-                            'path' => $this->path,
-                            'filter' => $this->filter?->toArray(),
-                            'nested' => $this->nested?->toArray(),
-                            'max_children' => $this->maxChildren,
-                        ]
-                    ),
-                ]
-            ),
+            $this->field => $payload,
         ];
     }
 }

--- a/src/Sorts/Sort.php
+++ b/src/Sorts/Sort.php
@@ -23,15 +23,22 @@ class Sort implements Sorting
 
     public function toArray(): array
     {
-        return [
-            $this->field => array_filter(
-                [
+        $payload = array_filter(
+            [
                     'order' => $this->order,
                     'missing' => $this->missing,
                     'unmapped_type' => $this->unmappedType,
                     'mode' => $this->mode,
-                ]
-            ),
+            ]
+        );
+
+        // missing can be empty string or zero value
+        if ($this->missing !== null) {
+            $payload['missing'] = $this->missing;
+        }
+
+        return [
+            $this->field => $payload,
         ];
     }
 }

--- a/tests/Queries/CollapseTest.php
+++ b/tests/Queries/CollapseTest.php
@@ -10,7 +10,6 @@ use Spatie\ElasticsearchQueryBuilder\Builder;
 
 class CollapseTest extends TestCase
 {
-
     private Builder $builder;
 
     private Client $client;


### PR DESCRIPTION
### Problem description

**Current Issue:**

The `missing` parameter in aggregations and sorts is currently restricted to `string` type only, which limits its usage according to Elasticsearch documentation. According to [Elasticsearch official documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-missing-aggregation.html), the `missing` parameter can accept various types including:

- **Strings** (e.g., `"0"`, `"_last"`, `"_first"`)
- **Numbers** (e.g., `0`, `10`, `100.5`, `-50`)  
- **Booleans** (e.g., `true`, `false`)

**Current Type Restrictions:**

1. **Aggregations (`WithMissing` trait):**
   ```php
   protected ?string $missing = null;
   public function missing(string $missingValue): self
   ```

2. **Sorts (`HasMissing` trait):**
   ```php
   protected ?string $missing = null;
   public function missing(string $missing): static
   ```

**Impact on Usage:**

- **Numeric aggregations** (like `SumAggregation`, `MaxAggregation`, `MinAggregation`) often need numeric default values (e.g., `0` for sums, `-999` for missing prices)
- **Boolean field sorting** requires boolean values for proper handling of missing values
- **Current workaround**: Developers must convert all values to strings, which is counter-intuitive and type-unsafe

**Examples of Current Limitations:**
```php
// ❌ Current - Must convert number to string
SumAggregation::create('total_price', 'price')->missing('0');  

// ❌ Current - Must convert boolean to string  
Sort::create('is_active')->missing('false');

// ✅ Desired - Use native types
SumAggregation::create('total_price', 'price')->missing(0);
Sort::create('is_active')->missing(false);
```

### Solution

Updated type declarations to support multiple types using PHP 8.0+ union types:

**Aggregations:**
```php
protected string|int|float|bool|null $missing = null;
public function missing(string|int|float|bool $missingValue): self
```

**Sorts:**
```php
protected string|int|float|bool|null $missing = null;
public function missing(string|int|float|bool $missing): static
```

### Compatibility

- ✅ **Backwards compatible** - existing string usage continues to work
- ✅ **All existing tests pass** - no breaking changes to current functionality
- ✅ **Enhanced type safety** - developers can now use native PHP types matching Elasticsearch expectations