### PR TITLE
Added `ScriptSort` on Query Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,37 @@ $builder
     );
 ```
 
+### ScriptSort (Custom Script Sorting)
+
+The `ScriptSort` allows you to sort search results using custom Elasticsearch scripts. This can be helpful when you want complex sorting logic based on document fields or custom calculations.
+
+Example usage with a painless script:
+
+```php
+use Spatie\ElasticsearchQueryBuilder\Sorts\ScriptSort;
+use Spatie\ElasticsearchQueryBuilder\Builder;
+
+$client = Elastic\Elasticsearch\ClientBuilder::create()->build();
+
+$builder = new Builder($client);
+
+$builder->addSort(
+    ScriptSort::create(
+        "doc['field_name'].value * params.factor", // painless script
+        ScriptSort::DESC,
+        ['factor' => 1.5] // parameters for the script
+    )
+);
+
+$response = $builder->search();
+```
+
+-   The first parameter is the painless script expression.
+-   The second parameter is the sort order: `ScriptSort::ASC` or `ScriptSort::DESC`.
+-   The third parameter is an optional associative array of parameters passed to the script.
+
+This feature gives you flexible control over sorting logic beyond standard field-based sorts.
+
 ## Retrieve specific fields
 
 The `fields()` method can be used to request specific fields from the resulting documents without returning the entire `_source` entry. You can read more about the specifics of the fields parameter in [the ElasticSearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html).

--- a/src/Sorts/ScriptSort.php
+++ b/src/Sorts/ScriptSort.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Sorts;
+
+use Spatie\ElasticsearchQueryBuilder\Sorts\Sorting;
+
+class ScriptSort implements Sorting
+{
+    protected string $scriptSource;
+    protected string $order;
+    protected string $lang = 'painless';
+    protected string $type = 'number';
+    protected array $params = [];
+
+    public function __construct(
+        string $scriptSource,
+        string $order = self::ASC,
+        string $lang = 'painless',
+        string $type = 'number',
+        array $params = []
+    ) {
+        $this->scriptSource = $scriptSource;
+        $this->order = $order;
+        $this->lang = $lang;
+        $this->type = $type;
+        $this->params = $params;
+    }
+
+    public static function create(
+        string $scriptSource,
+        string $order = self::ASC,
+        string $lang = 'painless',
+        string $type = 'number',
+        array $params = []
+    ): static {
+        return new static($scriptSource, $order, $lang, $type, $params);
+    }
+
+    public function setOrder(string $order): self
+    {
+        $this->order = $order;
+        return $this;
+    }
+
+    public function setLang(string $lang): self
+    {
+        $this->lang = $lang;
+        return $this;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function setParams(array $params): self
+    {
+        $this->params = $params;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        $scriptArray = [
+            'source' => $this->scriptSource,
+            'lang' => $this->lang,
+        ];
+
+        if (!empty($this->params)) {
+            $scriptArray['params'] = $this->params;
+        }
+
+        return [
+            '_script' => [
+                'type' => $this->type,
+                'script' => $scriptArray,
+                'order' => $this->order,
+            ],
+        ];
+    }
+}

--- a/tests/Sorts/ScriptSortTest.php
+++ b/tests/Sorts/ScriptSortTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Sorts;
+
+use PHPUnit\Framework\TestCase;
+use App\Elasticsearch\ScriptSort;
+use Spatie\ElasticsearchQueryBuilder\Sorts\Sorting;
+
+class ScriptSortTest extends TestCase
+{
+    private ScriptSort $scriptSort;
+
+    protected function setUp(): void
+    {
+        $this->scriptSort = new ScriptSort("doc['field'].value", Sorting::ASC);
+    }
+
+    public function testImplementsSortingInterface(): void
+    {
+        $this->assertInstanceOf(Sorting::class, $this->scriptSort);
+    }
+
+    public function testToArrayBuildsCorrectSort(): void
+    {
+        $expected = [
+            '_script' => [
+                'type' => 'number',
+                'script' => [
+                    'source' => "doc['field'].value",
+                    'lang' => 'painless',
+                ],
+                'order' => Sorting::ASC,
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->scriptSort->toArray());
+    }
+
+    public function testToArrayIncludesParams(): void
+    {
+        $scriptSource = "params.threshold > 10 ? 1 : 0";
+        $params = ['threshold' => 15];
+
+        $scriptSort = ScriptSort::create($scriptSource, Sorting::DESC)
+            ->setParams($params);
+
+        $expected = [
+            '_script' => [
+                'type' => 'number',
+                'script' => [
+                    'source' => $scriptSource,
+                    'lang' => 'painless',
+                    'params' => $params,
+                ],
+                'order' => Sorting::DESC,
+            ],
+        ];
+
+        $this->assertEquals($expected, $scriptSort->toArray());
+    }
+
+    public function testCanSetLang(): void
+    {
+        $scriptSort = ScriptSort::create("return 1;", Sorting::ASC)
+            ->setLang('expression');
+
+        $expected = [
+            '_script' => [
+                'type' => 'number',
+                'script' => [
+                    'source' => "return 1;",
+                    'lang' => 'expression',
+                ],
+                'order' => Sorting::ASC,
+            ],
+        ];
+
+        $this->assertEquals($expected, $scriptSort->toArray());
+    }
+
+    public function testCanSetType(): void
+    {
+        $scriptSort = ScriptSort::create("doc['field'].value", Sorting::ASC)
+            ->setType('string');
+
+        $expected = [
+            '_script' => [
+                'type' => 'string',
+                'script' => [
+                    'source' => "doc['field'].value",
+                    'lang' => 'painless',
+                ],
+                'order' => Sorting::ASC,
+            ],
+        ];
+
+        $this->assertEquals($expected, $scriptSort->toArray());
+    }
+
+    public function testCanSetOrder(): void
+    {
+        $scriptSort = ScriptSort::create("doc['field'].value", Sorting::ASC)
+            ->setOrder(Sorting::DESC);
+
+        $expected = [
+            '_script' => [
+                'type' => 'number',
+                'script' => [
+                    'source' => "doc['field'].value",
+                    'lang' => 'painless',
+                ],
+                'order' => Sorting::DESC,
+            ],
+        ];
+
+        $this->assertEquals($expected, $scriptSort->toArray());
+    }
+}

--- a/tests/Sorts/ScriptSortTest.php
+++ b/tests/Sorts/ScriptSortTest.php
@@ -3,7 +3,7 @@
 namespace Spatie\ElasticsearchQueryBuilder\Tests\Sorts;
 
 use PHPUnit\Framework\TestCase;
-use App\Elasticsearch\ScriptSort;
+use Spatie\ElasticsearchQueryBuilder\Sorts\ScriptSort;
 use Spatie\ElasticsearchQueryBuilder\Sorts\Sorting;
 
 class ScriptSortTest extends TestCase


### PR DESCRIPTION
- Enables sorting based on custom painless scripts.
- Supports passing parameters to the script for dynamic behavior.
- Useful for sorting by computed values not stored in a single field.
- Fully compatible with Elasticsearch's `_script` sort type.
- Accepts ascending (`ASC`) or descending (`DESC`) order.