### PR TITLE
feat: add where feature like laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ $builder
     ->orWhere('team', 'search')
     ->whereNot('status', 'archived')
     ->whereIn('user.id', ['flx', 'fly'])
-    ->whereBetween('age', 18, 65)
+    ->whereBetween('age', [18, 65])
     ->whereNull('deleted_at')
     ->whereNotNull('published_at')
     ->whereExists('email')
@@ -331,7 +331,7 @@ You can also group conditions using a closure, similar to nested where clauses i
 $builder->where(function (Builder $query): void {
     $query->where('category', 'book')
         ->orWhere(function (Builder $nested): void {
-            $nested->whereBetween('price', 10, 100)
+            $nested->whereBetween('price', [10, 100])
                 ->whereNotNull('published_at');
         });
 });

--- a/README.md
+++ b/README.md
@@ -289,6 +289,66 @@ $builder
 
 More information on the boolean query and its occurrence types can be found [in the ElasticSearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html).
 
+### Laravel-like where shortcuts
+
+If you prefer a Laravel-like API, you can use `where` shortcuts instead of creating `Query` objects manually.
+All shortcuts still map to the existing query classes under the hood, so `addQuery()` remains fully supported.
+
+```php
+$builder = new Builder($client);
+
+$builder
+    ->where('name', 'zs')
+    ->where('age', '>=', 1)
+    ->orWhere('team', 'search')
+    ->whereNot('status', 'archived')
+    ->whereIn('user.id', ['flx', 'fly'])
+    ->whereBetween('age', 18, 65)
+    ->whereNull('deleted_at')
+    ->whereNotNull('published_at')
+    ->whereExists('email')
+    ->wherePrefix('user.id', 'fl')
+    ->whereRegexp('name', 'jo.*', flags: 'ALL');
+```
+
+The `where()` method supports both two-argument and three-argument signatures:
+
+```php
+$builder
+    ->where('name', 'zs')           // field = value
+    ->where('age', '>=', 18)        // field operator value
+    ->where('status', '!=', 'archived')
+    ->where('user.id', 'in', ['flx', 'fly'])
+    ->where('score', 'between', [60, 100]);
+```
+
+Supported operators for the three-argument form are:
+`=`, `==`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `in`, `not in`, `between`, `not between`.
+
+You can also group conditions using a closure, similar to nested where clauses in Laravel:
+
+```php
+$builder->where(function (Builder $query): void {
+    $query->where('category', 'book')
+        ->orWhere(function (Builder $nested): void {
+            $nested->whereBetween('price', 10, 100)
+                ->whereNotNull('published_at');
+        });
+});
+```
+
+For advanced control, closure groups also accept a `BoolQuery` directly:
+
+```php
+use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\TermQuery;
+
+$builder->where(function (BoolQuery $bool): void {
+    $bool->add(TermQuery::create('is_active', true))
+        ->add(TermQuery::create('is_deleted', true), 'must_not');
+});
+```
+
 ## Adding aggregations
 
 The `$builder->addAggregation()` method can be used to add any of the available `Aggregation`s to the builder. The available aggregation types can be found below or in the `src/Aggregations` directory of this repo. Every `Aggregation` has a static `create()` method to pass its most important parameters and sometimes some extra methods.

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -6,15 +6,17 @@ use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use Http\Promise\Promise;
 use Spatie\ElasticsearchQueryBuilder\Aggregations\Aggregation;
+use Spatie\ElasticsearchQueryBuilder\Concerns\HasWhereClauses;
 use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
 use Spatie\ElasticsearchQueryBuilder\Queries\Query;
 use Spatie\ElasticsearchQueryBuilder\Sorts\Sorting;
-use Spatie\ElasticsearchQueryBuilder\Traits\Conditionable;
+use Spatie\ElasticsearchQueryBuilder\Concerns\Conditionable;
 
 class Builder
 {
     use Conditionable;
+    use HasWhereClauses;
     
     protected ?BoolQuery $query = null;
 

--- a/src/Concerns/Conditionable.php
+++ b/src/Concerns/Conditionable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\ElasticsearchQueryBuilder\Traits;
+namespace Spatie\ElasticsearchQueryBuilder\Concerns;
 
 trait Conditionable
 {

--- a/src/Concerns/HasWhereClauses.php
+++ b/src/Concerns/HasWhereClauses.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Concerns;
+
+use Closure;
+use ReflectionFunction;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+use Spatie\ElasticsearchQueryBuilder\Builder;
+use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\ExistsQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\PrefixQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\RangeQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\RegexpQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\TermQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\TermsQuery;
+
+trait HasWhereClauses
+{
+    public function where(string|Closure $field, mixed $operatorOrValue = null, mixed $value = null, string $boolType = 'must'): static
+    {
+        if ($field instanceof Closure) {
+            $resolvedBoolType = is_string($operatorOrValue) ? $operatorOrValue : $boolType;
+
+            return $this->addWhereGroup($field, $resolvedBoolType);
+        }
+
+        if (! $this->isWhereOperator($operatorOrValue)) {
+            if ($operatorOrValue === null) {
+                return $this->whereNull($field);
+            }
+
+            return $this->addQuery(TermQuery::create($field, $operatorOrValue), $boolType);
+        }
+
+        return $this->applyWhereOperator($field, (string) $operatorOrValue, $value, $boolType);
+    }
+
+    public function orWhere(string|Closure $field, mixed $operatorOrValue = null, mixed $value = null): static
+    {
+        return $this->where($field, $operatorOrValue, $value, 'should');
+    }
+
+    public function whereNot(string|Closure $field, mixed $operatorOrValue = null, mixed $value = null): static
+    {
+        return $this->where($field, $operatorOrValue, $value, 'must_not');
+    }
+
+    public function whereIn(string $field, array $values, string $boolType = 'must', null|float $boost = null): static
+    {
+        return $this->addQuery(TermsQuery::create($field, $values, $boost), $boolType);
+    }
+
+    public function whereNotIn(string $field, array $values, null|float $boost = null): static
+    {
+        return $this->whereIn($field, $values, 'must_not', $boost);
+    }
+
+    public function whereBetween(string $field, array $range, string $boolType = 'must'): static {
+        return $this->addQuery(
+            RangeQuery::create($field)->gte($range[0])->lte($range[1]),
+            $boolType
+        );
+    }
+
+    public function whereNotBetween(string $field, array $range): static {
+        return $this->whereBetween($field, $range, 'must_not');
+    }
+
+    public function whereNull(string $field): static
+    {
+        return $this->whereExists($field, 'must_not');
+    }
+
+    public function whereNotNull(string $field): static
+    {
+        return $this->whereExists($field);
+    }
+
+    public function whereExists(string $field, string $boolType = 'must'): static
+    {
+        return $this->addQuery(ExistsQuery::create($field), $boolType);
+    }
+
+    public function wherePrefix(string $field, string|int $query, string $boolType = 'must'): static
+    {
+        return $this->addQuery(PrefixQuery::create($field, $query), $boolType);
+    }
+
+    public function whereRegexp(
+        string $field,
+        string $value,
+        string $boolType = 'must',
+        ?string $flags = null,
+        ?int $maxDeterminizedStates = null,
+        ?float $boost = null,
+        ?string $rewrite = null
+    ): static {
+        return $this->addQuery(
+            RegexpQuery::create($field, $value, $flags, $maxDeterminizedStates, $boost, $rewrite),
+            $boolType
+        );
+    }
+
+    private function addWhereGroup(Closure $callback, string $boolType): static
+    {
+        $nestedBuilder = new self($this->client);
+        $nestedBoolQuery = BoolQuery::create();
+
+        $argument = $this->resolveWhereCallbackArgument($callback, $nestedBuilder, $nestedBoolQuery);
+
+        if ($argument === null) {
+            $callback();
+        } else {
+            $callback($argument);
+        }
+
+        if ($nestedBuilder->query && ! $nestedBuilder->query->isEmpty()) {
+            if ($nestedBoolQuery->isEmpty()) {
+                return $this->addQuery($nestedBuilder->query, $boolType);
+            }
+
+            $nestedBoolQuery->add($nestedBuilder->query);
+        }
+
+        if ($nestedBoolQuery->isEmpty()) {
+            return $this;
+        }
+
+        return $this->addQuery($nestedBoolQuery, $boolType);
+    }
+
+    private function resolveWhereCallbackArgument(Closure $callback, Builder $nestedBuilder, BoolQuery $nestedBoolQuery): Builder|BoolQuery|null {
+        $reflection = new ReflectionFunction($callback);
+        $firstParameter = $reflection->getParameters()[0] ?? null;
+
+        if (! $firstParameter) {
+            return null;
+        }
+
+        $parameterType = $firstParameter->getType();
+
+        if ($this->parameterAcceptsClass($parameterType, Builder::class)) {
+            return $nestedBuilder;
+        }
+
+        if ($this->parameterAcceptsClass($parameterType, BoolQuery::class)) {
+            return $nestedBoolQuery;
+        }
+
+        return $nestedBuilder;
+    }
+
+    private function parameterAcceptsClass(?ReflectionType $type, string $className): bool
+    {
+        if (! $type) {
+            return false;
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            return ! $type->isBuiltin() && $type->getName() === $className;
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $unionedType) {
+                if ($unionedType instanceof ReflectionNamedType
+                    && ! $unionedType->isBuiltin()
+                    && $unionedType->getName() === $className) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function applyWhereOperator(string $field, string $operator, mixed $value, string $boolType): static
+    {
+        $normalizedOperator = strtolower(trim($operator));
+
+        return match ($normalizedOperator) {
+            '=' => $value === null ? $this->whereNull($field) : $this->addQuery(TermQuery::create($field, $value), $boolType),
+            '!=', '<>' => $value === null ? $this->whereNotNull($field) : $this->addQuery(TermQuery::create($field, $value), 'must_not'),
+            '>' => $this->addQuery(RangeQuery::create($field)->gt($value), $boolType),
+            '>=' => $this->addQuery(RangeQuery::create($field)->gte($value), $boolType),
+            '<' => $this->addQuery(RangeQuery::create($field)->lt($value), $boolType),
+            '<=' => $this->addQuery(RangeQuery::create($field)->lte($value), $boolType),
+            'in' => $this->whereIn($field, is_array($value) ? $value : [$value], $boolType),
+            'not in' => $this->whereNotIn($field, is_array($value) ? $value : [$value]),
+            'between' => $this->whereBetween($field, $value[0] ?? null, $value[1] ?? null, $boolType),
+            'not between' => $this->whereNotBetween($field, $value[0] ?? null, $value[1] ?? null),
+            default => $this->addQuery(TermQuery::create($field, $value), $boolType),
+        };
+    }
+
+    private function isWhereOperator(mixed $value): bool
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return in_array(strtolower(trim($value)), [
+            '=',
+            '!=',
+            '<>',
+            '>',
+            '>=',
+            '<',
+            '<=',
+            'in',
+            'not in',
+            'between',
+            'not between',
+        ], true);
+    }
+}

--- a/src/Concerns/HasWhereClauses.php
+++ b/src/Concerns/HasWhereClauses.php
@@ -28,7 +28,7 @@ trait HasWhereClauses
 
         if (! $this->isWhereOperator($operatorOrValue)) {
             if ($operatorOrValue === null) {
-                return $this->whereNull($field);
+                return $this->whereNull($field, $boolType);
             }
 
             return $this->addQuery(TermQuery::create($field, $operatorOrValue), $boolType);
@@ -58,8 +58,10 @@ trait HasWhereClauses
     }
 
     public function whereBetween(string $field, array $range, string $boolType = 'must'): static {
+        [$from, $to] = $this->normalizeBetweenRange($range);
+
         return $this->addQuery(
-            RangeQuery::create($field)->gte($range[0])->lte($range[1]),
+            RangeQuery::create($field)->gte($from)->lte($to),
             $boolType
         );
     }
@@ -68,14 +70,21 @@ trait HasWhereClauses
         return $this->whereBetween($field, $range, 'must_not');
     }
 
-    public function whereNull(string $field): static
+    public function whereNull(string $field, string $boolType = 'must'): static
     {
-        return $this->whereExists($field, 'must_not');
+        if ($boolType === 'must') {
+            return $this->whereExists($field, 'must_not');
+        }
+
+        return $this->addQuery(
+            BoolQuery::create()->add(ExistsQuery::create($field), 'must_not'),
+            $boolType
+        );
     }
 
-    public function whereNotNull(string $field): static
+    public function whereNotNull(string $field, string $boolType = 'must'): static
     {
-        return $this->whereExists($field);
+        return $this->whereExists($field, $boolType);
     }
 
     public function whereExists(string $field, string $boolType = 'must'): static
@@ -180,18 +189,23 @@ trait HasWhereClauses
         $normalizedOperator = strtolower(trim($operator));
 
         return match ($normalizedOperator) {
-            '=' => $value === null ? $this->whereNull($field) : $this->addQuery(TermQuery::create($field, $value), $boolType),
-            '!=', '<>' => $value === null ? $this->whereNotNull($field) : $this->addQuery(TermQuery::create($field, $value), 'must_not'),
+            '=' => $value === null ? $this->whereNull($field, $boolType) : $this->addQuery(TermQuery::create($field, $value), $boolType),
+            '!=', '<>' => $value === null ? $this->whereNotNull($field, $boolType) : $this->addQuery(TermQuery::create($field, $value), 'must_not'),
             '>' => $this->addQuery(RangeQuery::create($field)->gt($value), $boolType),
             '>=' => $this->addQuery(RangeQuery::create($field)->gte($value), $boolType),
             '<' => $this->addQuery(RangeQuery::create($field)->lt($value), $boolType),
             '<=' => $this->addQuery(RangeQuery::create($field)->lte($value), $boolType),
             'in' => $this->whereIn($field, is_array($value) ? $value : [$value], $boolType),
             'not in' => $this->whereNotIn($field, is_array($value) ? $value : [$value]),
-            'between' => $this->whereBetween($field, $value[0] ?? null, $value[1] ?? null, $boolType),
-            'not between' => $this->whereNotBetween($field, $value[0] ?? null, $value[1] ?? null),
+            'between' => $this->whereBetween($field, is_array($value) ? $value : [$value], $boolType),
+            'not between' => $this->whereNotBetween($field, is_array($value) ? $value : [$value]),
             default => $this->addQuery(TermQuery::create($field, $value), $boolType),
         };
+    }
+
+    private function normalizeBetweenRange(array $range): array
+    {
+        return array_values($range) + [null, null];
     }
 
     private function isWhereOperator(mixed $value): bool

--- a/src/Concerns/HasWhereClauses.php
+++ b/src/Concerns/HasWhereClauses.php
@@ -11,6 +11,7 @@ use Spatie\ElasticsearchQueryBuilder\Builder;
 use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\ExistsQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\PrefixQuery;
+use Spatie\ElasticsearchQueryBuilder\Queries\Query;
 use Spatie\ElasticsearchQueryBuilder\Queries\RangeQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\RegexpQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\TermQuery;
@@ -58,12 +59,7 @@ trait HasWhereClauses
     }
 
     public function whereBetween(string $field, array $range, string $boolType = 'must'): static {
-        [$from, $to] = $this->normalizeBetweenRange($range);
-
-        return $this->addQuery(
-            RangeQuery::create($field)->gte($from)->lte($to),
-            $boolType
-        );
+        return $this->addQuery($this->createBetweenRangeQuery($field, $range), $boolType);
     }
 
     public function whereNotBetween(string $field, array $range): static {
@@ -190,22 +186,46 @@ trait HasWhereClauses
 
         return match ($normalizedOperator) {
             '=' => $value === null ? $this->whereNull($field, $boolType) : $this->addQuery(TermQuery::create($field, $value), $boolType),
-            '!=', '<>' => $value === null ? $this->whereNotNull($field, $boolType) : $this->addQuery(TermQuery::create($field, $value), 'must_not'),
+            '!=', '<>' => $value === null
+                ? $this->whereNotNull($field, $boolType)
+                : $this->addNegatedQuery(TermQuery::create($field, $value), $boolType),
             '>' => $this->addQuery(RangeQuery::create($field)->gt($value), $boolType),
             '>=' => $this->addQuery(RangeQuery::create($field)->gte($value), $boolType),
             '<' => $this->addQuery(RangeQuery::create($field)->lt($value), $boolType),
             '<=' => $this->addQuery(RangeQuery::create($field)->lte($value), $boolType),
             'in' => $this->whereIn($field, is_array($value) ? $value : [$value], $boolType),
-            'not in' => $this->whereNotIn($field, is_array($value) ? $value : [$value]),
+            'not in' => $this->addNegatedQuery(
+                TermsQuery::create($field, is_array($value) ? $value : [$value]),
+                $boolType
+            ),
             'between' => $this->whereBetween($field, is_array($value) ? $value : [$value], $boolType),
-            'not between' => $this->whereNotBetween($field, is_array($value) ? $value : [$value]),
+            'not between' => $this->addNegatedQuery($this->createBetweenRangeQuery($field, is_array($value) ? $value : [$value]), $boolType),
             default => $this->addQuery(TermQuery::create($field, $value), $boolType),
         };
+    }
+
+    private function addNegatedQuery(Query $query, string $boolType): static
+    {
+        if ($boolType === 'must') {
+            return $this->addQuery($query, 'must_not');
+        }
+
+        return $this->addQuery(
+            BoolQuery::create()->add($query, 'must_not'),
+            $boolType
+        );
     }
 
     private function normalizeBetweenRange(array $range): array
     {
         return array_values($range) + [null, null];
+    }
+
+    private function createBetweenRangeQuery(string $field, array $range): Query
+    {
+        [$from, $to] = $this->normalizeBetweenRange($range);
+
+        return RangeQuery::create($field)->gte($from)->lte($to);
     }
 
     private function isWhereOperator(mixed $value): bool

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -7,6 +7,7 @@ use Elastic\Transport\TransportBuilder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Spatie\ElasticsearchQueryBuilder\Builder;
+use Spatie\ElasticsearchQueryBuilder\Queries\BoolQuery;
 use Spatie\ElasticsearchQueryBuilder\Queries\NestedQuery\InnerHits;
 use Spatie\ElasticsearchQueryBuilder\Sorts\Sort;
 
@@ -81,5 +82,484 @@ class BuilderTest extends TestCase
 
         $this->assertArrayHasKey('min_score', $payload);
         $this->assertEquals(0.1, $payload['min_score']);
+    }
+
+    public function testWhereAddsTermQueryToPayload(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where('name', 'zs')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'term' => [
+                                'name' => 'zs',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereSupportsThreeArgumentsWithGreaterThanOrEqualOperator(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where('age', '>=', 1)
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'range' => [
+                                'age' => [
+                                    'gte' => 1,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereSupportsThreeArgumentsWithNotEqualOperator(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where('status', '!=', 'archived')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        [
+                            'term' => [
+                                'status' => 'archived',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereSupportsInOperator(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where('user.id', 'in', ['flx', 'fly'])
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'terms' => [
+                                'user.id' => ['flx', 'fly'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereSupportsBetweenOperator(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where('age', 'between', [18, 65])
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'range' => [
+                                'age' => [
+                                    'lte' => 65,
+                                    'gte' => 18,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testOrWhereAddsTermQueryToShouldOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->orWhere('team', 'A')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'should' => [
+                        [
+                            'term' => [
+                                'team' => 'A',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereNotAddsTermQueryToMustNotOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereNot('status', 'archived')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        [
+                            'term' => [
+                                'status' => 'archived',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereInAddsTermsQueryToPayload(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereIn('user.id', ['flx', 'fly'])
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'terms' => [
+                                'user.id' => ['flx', 'fly'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereNotInAddsTermsQueryToMustNotOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereNotIn('user.id', ['flx', 'fly'], 5.0)
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        [
+                            'terms' => [
+                                'user.id' => ['flx', 'fly'],
+                                'boost' => 5.0,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereBetweenAddsRangeQueryToPayload(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereBetween('age', 18, 65)
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'range' => [
+                                'age' => [
+                                    'lte' => 65,
+                                    'gte' => 18,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereNotBetweenAddsRangeQueryToMustNotOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereNotBetween('age', 18, 65)
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        [
+                            'range' => [
+                                'age' => [
+                                    'lte' => 65,
+                                    'gte' => 18,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereNullAddsMustNotExistsQuery(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereNull('deleted_at')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must_not' => [
+                        [
+                            'exists' => [
+                                'field' => 'deleted_at',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereNotNullAddsExistsQuery(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereNotNull('deleted_at')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'exists' => [
+                                'field' => 'deleted_at',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWherePrefixAddsPrefixQuery(): void
+    {
+        $payload = (new Builder($this->client))
+            ->wherePrefix('user.id', 'fl')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'prefix' => [
+                                'user.id' => [
+                                    'value' => 'fl',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereRegexpAddsRegexpQuery(): void
+    {
+        $payload = (new Builder($this->client))
+            ->whereRegexp('name', 'jo.*', flags: 'ALL', maxDeterminizedStates: 10000, boost: 2.5, rewrite: 'constant_score')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'regexp' => [
+                                'name' => [
+                                    'value' => 'jo.*',
+                                    'flags' => 'ALL',
+                                    'max_determinized_states' => 10000,
+                                    'boost' => 2.5,
+                                    'rewrite' => 'constant_score',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereClosureReceivesBuilder(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where(function (Builder $query): void {
+                $query->where('first_name', 'john')
+                    ->orWhere('last_name', 'doe');
+            })
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'bool' => [
+                                'must' => [
+                                    [
+                                        'term' => [
+                                            'first_name' => 'john',
+                                        ],
+                                    ],
+                                ],
+                                'should' => [
+                                    [
+                                        'term' => [
+                                            'last_name' => 'doe',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereClosureReceivesBoolQuery(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where(function (BoolQuery $bool): void {
+                $bool->add(\Spatie\ElasticsearchQueryBuilder\Queries\TermQuery::create('is_active', true))
+                    ->add(\Spatie\ElasticsearchQueryBuilder\Queries\TermQuery::create('is_deleted', true), 'must_not');
+            })
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'bool' => [
+                                'must' => [
+                                    [
+                                        'term' => [
+                                            'is_active' => true,
+                                        ],
+                                    ],
+                                ],
+                                'must_not' => [
+                                    [
+                                        'term' => [
+                                            'is_deleted' => true,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testWhereClosureWithNoConditionsDoesNotChangePayload(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where(function (Builder $query): void {
+            })
+            ->getPayload();
+
+        self::assertEquals([], $payload);
+    }
+
+    public function testNestedWhereClosureCanBuildComplexQueries(): void
+    {
+        $payload = (new Builder($this->client))
+            ->where('tenant_id', 'acme')
+            ->where(function (Builder $query): void {
+                $query->where('category', 'book')
+                    ->orWhere(function (Builder $nestedQuery): void {
+                        $nestedQuery->whereBetween('price', 10, 100)
+                            ->whereNotNull('published_at');
+                    });
+            })
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'term' => [
+                                'tenant_id' => 'acme',
+                            ],
+                        ],
+                        [
+                            'bool' => [
+                                'must' => [
+                                    [
+                                        'term' => [
+                                            'category' => 'book',
+                                        ],
+                                    ],
+                                ],
+                                'should' => [
+                                    [
+                                        'bool' => [
+                                            'must' => [
+                                                [
+                                                    'range' => [
+                                                        'price' => [
+                                                            'lte' => 100,
+                                                            'gte' => 10,
+                                                        ],
+                                                    ],
+                                                ],
+                                                [
+                                                    'exists' => [
+                                                        'field' => 'published_at',
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
     }
 }

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -149,6 +149,33 @@ class BuilderTest extends TestCase
         ], $payload);
     }
 
+    public function testOrWhereWithNotEqualOperatorKeepsShouldOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->orWhere('status', '!=', 'archived')
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'should' => [
+                        [
+                            'bool' => [
+                                'must_not' => [
+                                    [
+                                        'term' => [
+                                            'status' => 'archived',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
     public function testOrWhereWithNullEqualOperatorKeepsShouldOccurrence(): void
     {
         $payload = (new Builder($this->client))
@@ -165,6 +192,63 @@ class BuilderTest extends TestCase
                                     [
                                         'exists' => [
                                             'field' => 'status',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testOrWhereWithNotInOperatorKeepsShouldOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->orWhere('user.id', 'not in', ['flx', 'fly'])
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'should' => [
+                        [
+                            'bool' => [
+                                'must_not' => [
+                                    [
+                                        'terms' => [
+                                            'user.id' => ['flx', 'fly'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
+    public function testOrWhereWithNotBetweenOperatorKeepsShouldOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->orWhere('age', 'not between', [18, 65])
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'should' => [
+                        [
+                            'bool' => [
+                                'must_not' => [
+                                    [
+                                        'range' => [
+                                            'age' => [
+                                                'lte' => 65,
+                                                'gte' => 18,
+                                            ],
                                         ],
                                     ],
                                 ],

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -149,6 +149,33 @@ class BuilderTest extends TestCase
         ], $payload);
     }
 
+    public function testOrWhereWithNullEqualOperatorKeepsShouldOccurrence(): void
+    {
+        $payload = (new Builder($this->client))
+            ->orWhere('status', '=', null)
+            ->getPayload();
+
+        self::assertEquals([
+            'query' => [
+                'bool' => [
+                    'should' => [
+                        [
+                            'bool' => [
+                                'must_not' => [
+                                    [
+                                        'exists' => [
+                                            'field' => 'status',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $payload);
+    }
+
     public function testWhereSupportsInOperator(): void
     {
         $payload = (new Builder($this->client))
@@ -282,7 +309,7 @@ class BuilderTest extends TestCase
     public function testWhereBetweenAddsRangeQueryToPayload(): void
     {
         $payload = (new Builder($this->client))
-            ->whereBetween('age', 18, 65)
+            ->whereBetween('age', [18, 65])
             ->getPayload();
 
         self::assertEquals([
@@ -306,7 +333,7 @@ class BuilderTest extends TestCase
     public function testWhereNotBetweenAddsRangeQueryToMustNotOccurrence(): void
     {
         $payload = (new Builder($this->client))
-            ->whereNotBetween('age', 18, 65)
+            ->whereNotBetween('age', [18, 65])
             ->getPayload();
 
         self::assertEquals([
@@ -510,7 +537,7 @@ class BuilderTest extends TestCase
             ->where(function (Builder $query): void {
                 $query->where('category', 'book')
                     ->orWhere(function (Builder $nestedQuery): void {
-                        $nestedQuery->whereBetween('price', 10, 100)
+                        $nestedQuery->whereBetween('price', [10, 100])
                             ->whereNotNull('published_at');
                     });
             })


### PR DESCRIPTION
Implement Laravel-like `where` shortcuts in Builder class for enhanced query building capabilities @freekmurze 
```php
$builder = new Builder($client);

$builder
    ->where('name', 'zs')
    ->where('age', '>=', 1)
    ->orWhere('team', 'search')
    ->whereNot('status', 'archived')
    ->whereIn('user.id', ['flx', 'fly'])
    ->whereBetween('age', [18, 65])
    ->whereNull('deleted_at')
    ->whereNotNull('published_at')
    ->whereExists('email')
    ->wherePrefix('user.id', 'fl')
    ->whereRegexp('name', 'jo.*', flags: 'ALL');
```