### PR TITLE
Add support for "fields" query parameter and for omitting "_source" in result

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -15,7 +15,7 @@ use Spatie\ElasticsearchQueryBuilder\Traits\Conditionable;
 class Builder
 {
     use Conditionable;
-    
+
     protected ?BoolQuery $query = null;
 
     protected ?AggregationCollection $aggregations = null;
@@ -32,7 +32,9 @@ class Builder
 
     protected ?array $searchAfter = null;
 
-    protected ?array $fields = null;
+    protected array|false|null $fields = null;
+
+    protected ?array $mappingFields = null;
 
     protected bool $withAggregations = true;
 
@@ -155,9 +157,30 @@ class Builder
         return $this;
     }
 
-    public function fields(array $fields): static
+    /**
+     * @deprecated
+     */
+    public function fields(array|false $fields): static
     {
+        return $this->source($fields);
+    }
+
+    public function source(array|false $fields): static
+    {
+        if ($fields === false) {
+            $this->fields = false;
+
+            return $this;
+        }
+
         $this->fields = array_merge($this->fields ?? [], $fields);
+
+        return $this;
+    }
+
+    public function mappingFields(array $fields): static
+    {
+        $this->mappingFields = array_merge($this->mappingFields ?? [], $fields);
 
         return $this;
     }
@@ -233,8 +256,12 @@ class Builder
             $payload['sort'] = $this->sorts->toArray();
         }
 
-        if ($this->fields) {
+        if ($this->fields !== null) {
             $payload['_source'] = $this->fields;
+        }
+
+        if ($this->mappingFields) {
+            $payload['fields'] = $this->mappingFields;
         }
 
         if ($this->searchAfter) {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -173,7 +173,7 @@ class Builder
             return $this;
         }
 
-        $this->fields = array_merge($this->fields ?? [], $fields);
+        $this->fields = array_merge($this->fields ?: [], $fields);
 
         return $this;
     }

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -82,4 +82,31 @@ class BuilderTest extends TestCase
         $this->assertArrayHasKey('min_score', $payload);
         $this->assertEquals(0.1, $payload['min_score']);
     }
+
+    /**
+     * This test is to document current behavior
+     * and catch breaking changes if the "fields" method should be renamed at some point
+     * (to better reflect the payload parameter).
+     */
+    public function testTreatsFieldsAsSourceFields(): void
+    {
+        $builder = (new Builder($this->client))
+            ->fields([ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ]);
+
+        $this->assertEquals(
+            [ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ],
+            $builder->getPayload()['_source']
+        );
+    }
+
+    public function testFilterMappingFields(): void
+    {
+        $builder = (new Builder($this->client))
+            ->source(false)
+            ->mappingFields([ 'my_mapping_field' ]);
+
+        $payload = $builder->getPayload();
+        $this->assertEquals([ 'my_mapping_field' ], $payload['fields']);
+        $this->assertFalse($payload['_source']);
+    }
 }

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -103,6 +103,9 @@ class BuilderTest extends TestCase
     {
         $builder = (new Builder($this->client))
             ->source(false)
+            // Switch back and forth between types to check compatibility.
+            ->source(['my_other_mapping_field'])
+            ->source(false)
             ->mappingFields([ 'my_mapping_field' ]);
 
         $payload = $builder->getPayload();

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -31,7 +31,7 @@ class BuilderTest extends TestCase
             'name' => 'first_group',
             'size' => 1,
             'sort' => [
-                [ 'name.keyword' => [ 'order' => 'asc' ] ],
+                ['name.keyword' => ['order' => 'asc']],
             ],
         ];
 
@@ -39,7 +39,7 @@ class BuilderTest extends TestCase
             ->collapse('group_id', $innerHits);
 
         self::assertEquals(
-            [ 'collapse' => [ 'field' => 'group_id', 'inner_hits' => $innerHits ] ],
+            ['collapse' => ['field' => 'group_id', 'inner_hits' => $innerHits]],
             $builder->getPayload()
         );
     }
@@ -91,10 +91,10 @@ class BuilderTest extends TestCase
     public function testTreatsFieldsAsSourceFields(): void
     {
         $builder = (new Builder($this->client))
-            ->fields([ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ]);
+            ->fields(['includes' => ['my_included_source_field'], 'excludes' => ['my_excluded_source_field']]);
 
         $this->assertEquals(
-            [ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ],
+            ['includes' => ['my_included_source_field'], 'excludes' => ['my_excluded_source_field']],
             $builder->getPayload()['_source']
         );
     }
@@ -106,10 +106,10 @@ class BuilderTest extends TestCase
             // Switch back and forth between types to check compatibility.
             ->source(['my_other_mapping_field'])
             ->source(false)
-            ->mappingFields([ 'my_mapping_field' ]);
+            ->mappingFields(['my_mapping_field']);
 
         $payload = $builder->getPayload();
-        $this->assertEquals([ 'my_mapping_field' ], $payload['fields']);
+        $this->assertEquals(['my_mapping_field'], $payload['fields']);
         $this->assertFalse($payload['_source']);
     }
 }


### PR DESCRIPTION
This is also deprecating the "fields" method in favor of the more transparent "source" method.

Why is this important? Adding fields to the "source" parameter makes elasticsearch still get the entire document (stored in the "_source" field) and THEN filtering that data. the "fields" parameter only looks at the specified mapped fields (and respects the defined mapping for each field). This is especially useful when you only need a single field from each document. Setting "source" to false will omit the "_source" data from the result altogether.

I added a "source" method to reflect the "source" parameter, and a "mappingFields" method to reflect the "fields" parameter. The existing "fields" method (that was a mismatch with the "_source" parameter) I marked as deprecated to avoid a breaking change. This is not optimal and I'm totally open to suggestions.