### PR TITLE
Add source() and retrieveFields(), deprecate fields()

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,10 +520,37 @@ This feature gives you flexible control over sorting logic beyond standard field
 
 ## Retrieve specific fields
 
-The `fields()` method can be used to request specific fields from the resulting documents without returning the entire `_source` entry. You can read more about the specifics of the fields parameter in [the ElasticSearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html).
+ElasticSearch exposes two parameters for limiting what comes back in each hit: `_source` and `fields`. They behave differently and the builder maps each to a dedicated method.
+
+### `source()`
+
+The `source()` method writes to the `_source` parameter. ElasticSearch still loads the full stored document and then filters which top-level keys are returned. Pass an array of include paths (or an `includes`/`excludes` shape):
 
 ```php
-$builder->fields('user.id', 'http.*.status');
+$builder->source(['user.id', 'user.name']);
+
+$builder->source([
+    'includes' => ['user.*'],
+    'excludes' => ['user.password'],
+]);
+```
+
+Pass `false` to omit `_source` from each hit entirely:
+
+```php
+$builder->source(false);
+```
+
+The previously available `fields()` method has been deprecated in favor of `source()` since it wrote to `_source` despite its name. It still works and delegates to `source()`.
+
+### `retrieveFields()`
+
+The `retrieveFields()` method writes to the `fields` query parameter. ElasticSearch resolves the values through the index mapping instead of loading `_source`, which is meaningfully cheaper when you only need a handful of fields. See [the ElasticSearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html) for the trade-offs.
+
+```php
+$builder
+    ->source(false)
+    ->retrieveFields(['user.id', 'http.status']);
 ```
 
 ## Highlighting

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -15,7 +15,7 @@ use Spatie\ElasticsearchQueryBuilder\Traits\Conditionable;
 class Builder
 {
     use Conditionable;
-    
+
     protected ?BoolQuery $query = null;
 
     protected ?AggregationCollection $aggregations = null;
@@ -32,7 +32,9 @@ class Builder
 
     protected ?array $searchAfter = null;
 
-    protected ?array $fields = null;
+    protected array|false|null $fields = null;
+
+    protected ?array $mappingFields = null;
 
     protected bool $withAggregations = true;
 
@@ -155,9 +157,30 @@ class Builder
         return $this;
     }
 
-    public function fields(array $fields): static
+    /**
+     * @deprecated
+     */
+    public function fields(array|false $fields): static
     {
+        return $this->source($fields);
+    }
+
+    public function source(array|false $fields): static
+    {
+        if ($fields === false) {
+            $this->fields = false;
+
+            return $this;
+        }
+
         $this->fields = array_merge($this->fields ?? [], $fields);
+
+        return $this;
+    }
+
+    public function mappingFields(array $fields): static
+    {
+        $this->mappingFields = array_merge($this->mappingFields ?? [], $fields);
 
         return $this;
     }
@@ -233,8 +256,12 @@ class Builder
             $payload['sort'] = $this->sorts->toArray();
         }
 
-        if ($this->fields) {
+        if ($this->fields !== null) {
             $payload['_source'] = $this->fields;
+        }
+
+        if ($this->mappingFields) {
+            $payload['fields'] = $this->mappingFields;
         }
 
         if ($this->searchAfter) {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -34,7 +34,7 @@ class Builder
 
     protected array|false|null $fields = null;
 
-    protected ?array $mappingFields = null;
+    protected ?array $retrieveFields = null;
 
     protected bool $withAggregations = true;
 
@@ -46,14 +46,12 @@ class Builder
 
     protected ?array $collapse = null;
 
-    public function __construct(protected Client $client)
-    {
-    }
+    public function __construct(protected Client $client) {}
 
     public function addQuery(Query $query, string $boolType = 'must'): static
     {
         if (! $this->query) {
-            $this->query = new BoolQuery();
+            $this->query = new BoolQuery;
         }
 
         $this->query->add($query, $boolType);
@@ -64,7 +62,7 @@ class Builder
     public function addAggregation(Aggregation $aggregation): static
     {
         if (! $this->aggregations) {
-            $this->aggregations = new AggregationCollection();
+            $this->aggregations = new AggregationCollection;
         }
 
         $this->aggregations->add($aggregation);
@@ -75,7 +73,7 @@ class Builder
     public function addSort(Sorting $sort): static
     {
         if (! $this->sorts) {
-            $this->sorts = new SortCollection();
+            $this->sorts = new SortCollection;
         }
 
         $this->sorts->add($sort);
@@ -178,9 +176,9 @@ class Builder
         return $this;
     }
 
-    public function mappingFields(array $fields): static
+    public function retrieveFields(array $fields): static
     {
-        $this->mappingFields = array_merge($this->mappingFields ?? [], $fields);
+        $this->retrieveFields = array_merge($this->retrieveFields ?? [], $fields);
 
         return $this;
     }
@@ -202,7 +200,7 @@ class Builder
     public function addPostFilterQuery(Query $query, string $boolType = 'must'): static
     {
         if (! $this->postFilterQuery) {
-            $this->postFilterQuery = new BoolQuery();
+            $this->postFilterQuery = new BoolQuery;
         }
 
         $this->postFilterQuery->add($query, $boolType);
@@ -260,8 +258,8 @@ class Builder
             $payload['_source'] = $this->fields;
         }
 
-        if ($this->mappingFields) {
-            $payload['fields'] = $this->mappingFields;
+        if ($this->retrieveFields) {
+            $payload['fields'] = $this->retrieveFields;
         }
 
         if ($this->searchAfter) {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -46,7 +46,9 @@ class Builder
 
     protected ?array $collapse = null;
 
-    public function __construct(protected Client $client) {}
+    public function __construct(protected Client $client)
+    {
+    }
 
     public function addQuery(Query $query, string $boolType = 'must'): static
     {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -173,7 +173,7 @@ class Builder
             return $this;
         }
 
-        $this->fields = array_merge($this->fields ?? [], $fields);
+        $this->fields = array_merge($this->fields ?: [], $fields);
 
         return $this;
     }

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -82,4 +82,31 @@ class BuilderTest extends TestCase
         $this->assertArrayHasKey('min_score', $payload);
         $this->assertEquals(0.1, $payload['min_score']);
     }
+
+    /**
+     * This test is to document current behavior
+     * and catch breaking changes if the "fields" method should be renamed at some point
+     * (to better reflect the payload parameter).
+     */
+    public function testTreatsFieldsAsSourceFields(): void
+    {
+        $builder = (new Builder($this->client))
+            ->fields([ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ]);
+
+        $this->assertEquals(
+            [ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ],
+            $builder->getPayload()['_source']
+        );
+    }
+
+    public function testFilterMappingFields(): void
+    {
+        $builder = (new Builder($this->client))
+            ->source(false)
+            ->mappingFields([ 'my_mapping_field' ]);
+
+        $payload = $builder->getPayload();
+        $this->assertEquals([ 'my_mapping_field' ], $payload['fields']);
+        $this->assertFalse($payload['_source']);
+    }
 }

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -14,10 +14,10 @@ class BuilderTest extends TestCase
 {
     protected Client $client;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $transport = TransportBuilder::create()
-            ->setClient(new \Http\Mock\Client())
+            ->setClient(new \Http\Mock\Client)
             ->build();
 
         $logger = $this->createStub(LoggerInterface::class);
@@ -25,7 +25,7 @@ class BuilderTest extends TestCase
         $this->client = new Client($transport, $logger);
     }
 
-    public function testGeneratesCollapseWithPlainArrayData(): void
+    public function test_generates_collapse_with_plain_array_data(): void
     {
         $innerHits = [
             'name' => 'first_group',
@@ -44,7 +44,7 @@ class BuilderTest extends TestCase
         );
     }
 
-    public function testGeneratesCollapseWithInnerHitsObject(): void
+    public function test_generates_collapse_with_inner_hits_object(): void
     {
         $innerHits = InnerHits::create('first_group')
             ->size(1)
@@ -73,7 +73,7 @@ class BuilderTest extends TestCase
         );
     }
 
-    public function testMinScoreIsAppliedToThePayload(): void
+    public function test_min_score_is_applied_to_the_payload(): void
     {
         $payload = (new Builder($this->client))
             ->minScore(0.1)
@@ -88,7 +88,7 @@ class BuilderTest extends TestCase
      * and catch breaking changes if the "fields" method should be renamed at some point
      * (to better reflect the payload parameter).
      */
-    public function testTreatsFieldsAsSourceFields(): void
+    public function test_treats_fields_as_source_fields(): void
     {
         $builder = (new Builder($this->client))
             ->fields(['includes' => ['my_included_source_field'], 'excludes' => ['my_excluded_source_field']]);
@@ -99,17 +99,17 @@ class BuilderTest extends TestCase
         );
     }
 
-    public function testFilterMappingFields(): void
+    public function test_retrieve_fields(): void
     {
         $builder = (new Builder($this->client))
             ->source(false)
             // Switch back and forth between types to check compatibility.
-            ->source(['my_other_mapping_field'])
+            ->source(['my_source_field'])
             ->source(false)
-            ->mappingFields(['my_mapping_field']);
+            ->retrieveFields(['my_field']);
 
         $payload = $builder->getPayload();
-        $this->assertEquals(['my_mapping_field'], $payload['fields']);
+        $this->assertEquals(['my_field'], $payload['fields']);
         $this->assertFalse($payload['_source']);
     }
 }

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -103,6 +103,9 @@ class BuilderTest extends TestCase
     {
         $builder = (new Builder($this->client))
             ->source(false)
+            // Switch back and forth between types to check compatibility.
+            ->source(['my_other_mapping_field'])
+            ->source(false)
             ->mappingFields([ 'my_mapping_field' ]);
 
         $payload = $builder->getPayload();

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -31,7 +31,7 @@ class BuilderTest extends TestCase
             'name' => 'first_group',
             'size' => 1,
             'sort' => [
-                [ 'name.keyword' => [ 'order' => 'asc' ] ],
+                ['name.keyword' => ['order' => 'asc']],
             ],
         ];
 
@@ -39,7 +39,7 @@ class BuilderTest extends TestCase
             ->collapse('group_id', $innerHits);
 
         self::assertEquals(
-            [ 'collapse' => [ 'field' => 'group_id', 'inner_hits' => $innerHits ] ],
+            ['collapse' => ['field' => 'group_id', 'inner_hits' => $innerHits]],
             $builder->getPayload()
         );
     }
@@ -91,10 +91,10 @@ class BuilderTest extends TestCase
     public function testTreatsFieldsAsSourceFields(): void
     {
         $builder = (new Builder($this->client))
-            ->fields([ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ]);
+            ->fields(['includes' => ['my_included_source_field'], 'excludes' => ['my_excluded_source_field']]);
 
         $this->assertEquals(
-            [ 'includes' => [ 'my_included_source_field' ], 'excludes' => [ 'my_excluded_source_field' ] ],
+            ['includes' => ['my_included_source_field'], 'excludes' => ['my_excluded_source_field']],
             $builder->getPayload()['_source']
         );
     }
@@ -106,10 +106,10 @@ class BuilderTest extends TestCase
             // Switch back and forth between types to check compatibility.
             ->source(['my_other_mapping_field'])
             ->source(false)
-            ->mappingFields([ 'my_mapping_field' ]);
+            ->mappingFields(['my_mapping_field']);
 
         $payload = $builder->getPayload();
-        $this->assertEquals([ 'my_mapping_field' ], $payload['fields']);
+        $this->assertEquals(['my_mapping_field'], $payload['fields']);
         $this->assertFalse($payload['_source']);
     }
 }


### PR DESCRIPTION
Continuation of #81 by @sventendo (closed). His three commits are preserved as the first commits on this branch.

## Summary

- Adds `source()` to write to the `_source` payload parameter, with support for `source(false)` to omit `_source` from results entirely
- Adds `retrieveFields()` to write to the `fields` payload parameter (mapping-resolved values, no `_source` overhead)
- Deprecates `fields()` since it has always written to `_source` despite its name; it now delegates to `source()` so existing callers keep working

## Follow-up changes on top of @sventendo's work

- Renamed his new `mappingFields()` method to `retrieveFields()` to match the Elasticsearch docs terminology ("Retrieve selected fields") and to read more naturally in builder chains
- Rewrote the README's "Retrieve specific fields" section to cover the two distinct ES parameters and document `source()`, `source(false)`, the `fields()` deprecation, and `retrieveFields()`