### PR TITLE
Fix `ReverseNestedAggregation` emitting an empty `aggs` array

### DIFF
--- a/src/Aggregations/ReverseNestedAggregation.php
+++ b/src/Aggregations/ReverseNestedAggregation.php
@@ -27,9 +27,14 @@ class ReverseNestedAggregation extends Aggregation
 
     public function payload(): array
     {
-        return [
+        $aggregation = [
             'reverse_nested' => new stdClass(),
-            'aggs' => $this->aggregations->toArray(),
         ];
+
+        if (! $this->aggregations->isEmpty()) {
+            $aggregation['aggs'] = $this->aggregations->toArray();
+        }
+
+        return $aggregation;
     }
 }

--- a/tests/Aggregations/ReverseNestedAggregationTest.php
+++ b/tests/Aggregations/ReverseNestedAggregationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Aggregations;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\ReverseNestedAggregation;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\TermsAggregation;
+use stdClass;
+
+class ReverseNestedAggregationTest extends TestCase
+{
+    public function testCreateReturnsNewInstance(): void
+    {
+        $aggregation = ReverseNestedAggregation::create('test_name');
+
+        self::assertInstanceOf(ReverseNestedAggregation::class, $aggregation);
+    }
+
+    public function testDefaultSetupOmitsAggsKeyWhenThereAreNoSubAggregations(): void
+    {
+        $aggregation = new ReverseNestedAggregation('test_name');
+
+        $payload = $aggregation->toArray();
+
+        self::assertArrayNotHasKey('aggs', $payload);
+        self::assertEquals([
+            'reverse_nested' => new stdClass(),
+        ], $payload);
+    }
+
+    public function testDefaultSetupWithStaticCreateFunctionOmitsAggsKey(): void
+    {
+        $aggregation = ReverseNestedAggregation::create('test_name');
+
+        $payload = $aggregation->toArray();
+
+        self::assertArrayNotHasKey('aggs', $payload);
+        self::assertEquals([
+            'reverse_nested' => new stdClass(),
+        ], $payload);
+    }
+
+    public function testWithSubAggregation(): void
+    {
+        $aggregation = (new ReverseNestedAggregation('test_name'))
+            ->aggregation(new TermsAggregation('test_agg_name_1', 'test_agg_field_1'));
+
+        self::assertEquals([
+            'reverse_nested' => new stdClass(),
+            'aggs' => [
+                'test_agg_name_1' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_1',
+                    ],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testFullSetupWithMultipleSubAggregations(): void
+    {
+        $aggregation = new ReverseNestedAggregation(
+            'test_name',
+            new TermsAggregation('test_agg_name_1', 'test_agg_field_1'),
+            new TermsAggregation('test_agg_name_2', 'test_agg_field_2')
+        );
+
+        self::assertEquals([
+            'reverse_nested' => new stdClass(),
+            'aggs' => [
+                'test_agg_name_1' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_1',
+                    ],
+                ],
+                'test_agg_name_2' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_2',
+                    ],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testFullSetupWithStaticCreateFunction(): void
+    {
+        $aggregation = ReverseNestedAggregation::create(
+            'test_name',
+            TermsAggregation::create('test_agg_name_1', 'test_agg_field_1'),
+            TermsAggregation::create('test_agg_name_2', 'test_agg_field_2')
+        );
+
+        self::assertEquals([
+            'reverse_nested' => new stdClass(),
+            'aggs' => [
+                'test_agg_name_1' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_1',
+                    ],
+                ],
+                'test_agg_name_2' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_2',
+                    ],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testEncodingProducesJsonObjectNotArrayWhenThereAreNoSubAggregations(): void
+    {
+        $aggregation = ReverseNestedAggregation::create('test_name');
+
+        $json = json_encode($aggregation->toArray());
+
+        self::assertStringNotContainsString('"aggs":[]', $json);
+    }
+}


### PR DESCRIPTION
`ReverseNestedAggregation::payload()` always emitted an `aggs` key, even when no sub-aggregations were attached. Because an empty PHP array serializes to a JSON array (`[]`), Elasticsearch rejects the resulting payload since it expects `aggs` to be a JSON object:

```text
 parsing_exception: Expected [START_OBJECT] under [aggs], but got a [START_ARRAY] in [<aggregation_name>]
```

This change brings `ReverseNestedAggregation` in line with the existing behavior of the other aggregation classes ([TermsAggregation](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/TermsAggregation.php), [FilterAggregation](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/FilterAggregation.php), [DateHistogramAggregation](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/DateHistogramAggregation.php), and [HistogramAggregation](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/HistogramAggregation.php)), all of which only include the `aggs` key when `$this->aggregations->isEmpty()` is `false`. `ReverseNestedAggregation` was the only aggregation still missing this guard. It also adds missing test for `ReverseNestedAggregation`.

This aggregation is already documented for this package here: https://github.com/spatie/elasticsearch-query-builder#reversenestedaggregation

Further Elastic Search documentation:
- https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-reverse-nested-aggregation

In the documentation it can be seen that `aggs` is never an array but object. 


History:
- There was a PR that included this change https://github.com/spatie/elasticsearch-query-builder/pull/12 but was closed before getting merged in. 
