### PR TITLE
Add RangeAggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,18 @@ The following query types are available:
     ->missing(10);
 ```
 
+#### `RangeAggregation`
+
+[https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-range-aggregation](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-range-aggregation)
+
+```php
+\Spatie\ElasticsearchQueryBuilder\Aggregations\RangeAggregation::create('price_ranges', 'price', [
+    ['to' => 100.0],
+    ['from' => 100.0, 'to' => 200.0],
+    ['from' => 200.0],
+]);
+```
+
 #### `ReverseNestedAggregation`
 
 [https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html)

--- a/src/Aggregations/RangeAggregation.php
+++ b/src/Aggregations/RangeAggregation.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Aggregations;
+
+use Spatie\ElasticsearchQueryBuilder\AggregationCollection;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\Concerns\WithAggregations;
+
+class RangeAggregation extends Aggregation
+{
+    use WithAggregations;
+
+    protected string $field;
+
+    protected array $ranges;
+
+    public static function create(
+        string $name,
+        string $field,
+        array $ranges,
+        Aggregation ...$aggregations
+    ): self {
+        return new self($name, $field, $ranges, ...$aggregations);
+    }
+
+    public function __construct(
+        string $name,
+        string $field,
+        array $ranges,
+        Aggregation ...$aggregations
+    ) {
+        $this->name = $name;
+        $this->field = $field;
+        $this->ranges = $ranges;
+        $this->aggregations = new AggregationCollection(...$aggregations);
+    }
+
+    public function payload(): array
+    {
+        $aggregation = [
+            'range' => [
+                'field' => $this->field,
+                'ranges' => $this->ranges,
+            ],
+        ];
+
+        if (! $this->aggregations->isEmpty()) {
+            $aggregation['aggs'] = $this->aggregations->toArray();
+        }
+
+        return $aggregation;
+    }
+}

--- a/tests/Aggregations/RangeAggregationTest.php
+++ b/tests/Aggregations/RangeAggregationTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Spatie\ElasticsearchQueryBuilder\Tests\Aggregations;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\RangeAggregation;
+use Spatie\ElasticsearchQueryBuilder\Aggregations\TermsAggregation;
+
+class RangeAggregationTest extends TestCase
+{
+    public function testCreateReturnsNewInstance(): void
+    {
+        $aggregation = RangeAggregation::create('price_ranges', 'price', [
+            ['to' => 100.0],
+        ]);
+
+        self::assertInstanceOf(RangeAggregation::class, $aggregation);
+    }
+
+    public function testDefaultSetup(): void
+    {
+        $aggregation = new RangeAggregation('price_ranges', 'price', [
+            ['to' => 100.0],
+            ['from' => 100.0, 'to' => 200.0],
+            ['from' => 200.0],
+        ]);
+
+        self::assertEquals([
+            'range' => [
+                'field' => 'price',
+                'ranges' => [
+                    ['to' => 100.0],
+                    ['from' => 100.0, 'to' => 200.0],
+                    ['from' => 200.0],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testDefaultSetupWithStaticCreateFunction(): void
+    {
+        $aggregation = RangeAggregation::create('price_ranges', 'price', [
+            ['to' => 100.0],
+            ['from' => 100.0],
+        ]);
+
+        self::assertEquals([
+            'range' => [
+                'field' => 'price',
+                'ranges' => [
+                    ['to' => 100.0],
+                    ['from' => 100.0],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testWithCustomRangeKey(): void
+    {
+        $aggregation = RangeAggregation::create('price_ranges', 'price', [
+            ['key' => 'cheap', 'to' => 100.0],
+            ['key' => 'expensive', 'from' => 100.0],
+        ]);
+
+        self::assertEquals([
+            'range' => [
+                'field' => 'price',
+                'ranges' => [
+                    ['key' => 'cheap', 'to' => 100.0],
+                    ['key' => 'expensive', 'from' => 100.0],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testWithoutSubAggregationsOmitsAggsKey(): void
+    {
+        $aggregation = new RangeAggregation('price_ranges', 'price', [
+            ['to' => 100.0],
+        ]);
+
+        $payload = $aggregation->toArray();
+
+        self::assertArrayNotHasKey('aggs', $payload);
+    }
+
+    public function testWithSubAggregation(): void
+    {
+        $aggregation = (new RangeAggregation('price_ranges', 'price', [
+            ['to' => 100.0],
+        ]))->aggregation(new TermsAggregation('test_agg_name_1', 'test_agg_field_1'));
+
+        self::assertEquals([
+            'range' => [
+                'field' => 'price',
+                'ranges' => [
+                    ['to' => 100.0],
+                ],
+            ],
+            'aggs' => [
+                'test_agg_name_1' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_1',
+                    ],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testFullSetupWithMultipleSubAggregations(): void
+    {
+        $aggregation = new RangeAggregation(
+            'price_ranges',
+            'price',
+            [['to' => 100.0], ['from' => 100.0]],
+            new TermsAggregation('test_agg_name_1', 'test_agg_field_1'),
+            new TermsAggregation('test_agg_name_2', 'test_agg_field_2')
+        );
+
+        self::assertEquals([
+            'range' => [
+                'field' => 'price',
+                'ranges' => [
+                    ['to' => 100.0],
+                    ['from' => 100.0],
+                ],
+            ],
+            'aggs' => [
+                'test_agg_name_1' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_1',
+                    ],
+                ],
+                'test_agg_name_2' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_2',
+                    ],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+
+    public function testFullSetupWithStaticCreateFunction(): void
+    {
+        $aggregation = RangeAggregation::create(
+            'price_ranges',
+            'price',
+            [['to' => 100.0], ['from' => 100.0]],
+            TermsAggregation::create('test_agg_name_1', 'test_agg_field_1'),
+            TermsAggregation::create('test_agg_name_2', 'test_agg_field_2')
+        );
+
+        self::assertEquals([
+            'range' => [
+                'field' => 'price',
+                'ranges' => [
+                    ['to' => 100.0],
+                    ['from' => 100.0],
+                ],
+            ],
+            'aggs' => [
+                'test_agg_name_1' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_1',
+                    ],
+                ],
+                'test_agg_name_2' => [
+                    'terms' => [
+                        'field' => 'test_agg_field_2',
+                    ],
+                ],
+            ],
+        ], $aggregation->toArray());
+    }
+}


### PR DESCRIPTION
Adds `RangeAggregation` for Elasticsearch's `range` bucket aggregation, letting you define arbitrary numeric buckets (e.g. price bands). This library already implements the other core bucket aggregations ([Terms](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/TermsAggregation.php), [Histogram](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/HistogramAggregation.php), [DateHistogram](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/DateHistogramAggregation.php),
  [Nested](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/NestedAggregation.php), [ReverseNested](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/ReverseNestedAggregation.php), [Filter](https://github.com/spatie/elasticsearch-query-builder/blob/main/src/Aggregations/FilterAggregation.php)) but was missing `Range`. 

Follows the same conventions as the other bucket aggregations.

Elasticsearch's `range` aggregation lets you define arbitrary, unevenly-sized numeric buckets (e.g. price bands, age brackets), which `HistogramAggregation`'s fixed-width buckets can't express. 

Reference to Elasticsearch documentation: https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-range-aggregation

History:
- There was this PR https://github.com/spatie/elasticsearch-query-builder/pull/15/changes that wanted to add this same thing but was closed before it got merged in. 



